### PR TITLE
Remove useless eta expansion in bind notation.

### DIFF
--- a/theories/Mtac2.v
+++ b/theories/Mtac2.v
@@ -271,8 +271,8 @@ Notation "r '<-' t1 ';' t2" := (@bind _ _ t1 (fun r=> t2%MC))
   (at level 81, right associativity, format "'[' r  '<-'  '[' t1 ;  ']' ']' '/' t2 ") : Mtac_scope.
 Notation "t1 ';;' t2" := (@bind _ _ t1 (fun _=>t2%MC))
   (at level 81, right associativity, format "'[' '[' t1 ;;  ']' ']' '/' t2 ") : Mtac_scope.
-Notation "f @@ x" := (bind f (fun r=>(ret (r x))%MC)) (at level 70) : Mtac_scope.
-Notation "f >> x" := (bind f x) (at level 70) : Mtac_scope.
+Notation "t @@ x" := (bind t (fun r=>(ret (r x))%MC)) (at level 70) : Mtac_scope.
+Notation "t >> f" := (bind t f) (at level 70) : Mtac_scope.
 Open Scope string.
 
 (* We cannot make this notation recursive, so we loose

--- a/theories/Mtac2.v
+++ b/theories/Mtac2.v
@@ -272,7 +272,7 @@ Notation "r '<-' t1 ';' t2" := (@bind _ _ t1 (fun r=> t2%MC))
 Notation "t1 ';;' t2" := (@bind _ _ t1 (fun _=>t2%MC))
   (at level 81, right associativity, format "'[' '[' t1 ;;  ']' ']' '/' t2 ") : Mtac_scope.
 Notation "f @@ x" := (bind f (fun r=>(ret (r x))%MC)) (at level 70) : Mtac_scope.
-Notation "f >> x" := (bind f (fun r=>(x r) % MC)) (at level 70) : Mtac_scope.
+Notation "f >> x" := (bind f x) (at level 70) : Mtac_scope.
 Open Scope string.
 
 (* We cannot make this notation recursive, so we loose


### PR DESCRIPTION
What is the reason we are using the notation `>>` here? Why don't we use the more common notation `>>=`? Worse, this notation is confusing, in Haskell `x >> y` means `bind x (fun _ => y)` (for which we use the notation `;;`).