### PR TITLE
WIP: Make it possible to bind evars in match goal.

### DIFF
--- a/tests/test_goal_match.v
+++ b/tests/test_goal_match.v
@@ -32,3 +32,15 @@ MProof.
 intros x H y.
 match_goal ([[ (Q : x > 0) (z : nat) |- x = z ]] => reflexivity).
 Qed.
+
+Goal forall (x : nat) (H : x > 0) (y : bool), x = x.
+MProof.
+intros x H y.
+match_goal ([[? a | (Q : a > 0) (z : nat) |- a = z ]] => reflexivity).
+Qed.
+
+Goal forall (x : nat) (H : x > 0) (y : bool), 0 + x = x.
+MProof.
+intros x H y.
+match_goal ([[? a | (Q : a > 0) (z : nat) |- a = z ]] => apply (eq_refl a)).
+Qed.


### PR DESCRIPTION
In Ltac I often do stuff like:

```coq
match goal with
| |- ?x = _ => (* do stuff *)
end
```

This patch implements something like this for MetaCoq. The syntax is pretty bad and limited (hence the WIP). Suggestions for improvements?