### PR TITLE
match_goal with multiple clauses

### DIFF
--- a/tests/mctacticstests.v
+++ b/tests/mctacticstests.v
@@ -177,12 +177,12 @@ MProof.
 Qed.
 
 Definition testmg :=
-  ([[ (b : nat) |- S b > 0  ]] => fun g=>destruct b g)%goal_match.
+  match_goal with [[ (b : nat) |- S b > 0  ]] => fun g=>destruct b g end.
 
 Goal forall b : nat, S b > 0.
 MProof.
   intros b.
-  match_goal testmg.
+  testmg.
   - omega.
   - intros n'&> omega.
 Qed.
@@ -190,7 +190,7 @@ Qed.
 Goal forall a b : nat, S b > 0.
 MProof.
   intros a b.
-  match_goal testmg.
+  testmg.
   - omega.
   - intros n'&> omega.
 Qed.
@@ -198,7 +198,7 @@ Qed.
 Goal forall a b c : nat, S b > 0.
 MProof.
   intros a b c.
-  match_goal testmg.
+  testmg.
   - omega.
   - intros n'&> omega.
 Qed.
@@ -226,7 +226,7 @@ Qed.
 Goal forall x : bool, orb x true = true.
 MProof.
   intro x.
-  match_goal ([[ z:bool |- _ ]] => destruct  z).
+  match_goal with [[ z:bool |- _ ]] => destruct z end.
   - reflexivity.
   - reflexivity.
 Qed.
@@ -234,25 +234,25 @@ Qed.
 Goal forall (a b : nat) (Hb : b = 0) (Ha : a = 0), b = 0.
 MProof.
   intros a b Hb Ha.
-  match_goal ([[ (x:nat) (Hx : x = 0) |- x = 0 ]] => exact Hx).
+  match_goal with [[ (x:nat) (Hx : x = 0) |- x = 0 ]] => exact Hx end.
 Qed.
 
 Goal forall (a b : nat) (Hb : b = 0) (Ha : a = 0), a = 0.
 MProof.
   intros a b Hb Ha.
-  match_goal ([[ (x:nat) (Hx : x = 0) |- x = 0 ]] => exact Hx).
+  match_goal with [[ (x:nat) (Hx : x = 0) |- x = 0 ]] => exact Hx end.
 Qed.
 
 Goal forall (a b : nat) (Ha : a = 0) (Hb : b = 0), a = a.
 MProof.
   intros a b Ha Hb.
-  match_goal ([[ (x:nat) (Hx : x = 0) |- x = x ]] => reflexivity).
+  match_goal with [[ (x:nat) (Hx : x = 0) |- x = x ]] => reflexivity end.
 Qed.
 
 Goal forall (a b : nat) (Ha : a = 0) (Hb : b = 0), b = b.
 MProof.
   intros a b Ha Hb.
-  match_goal ([[ (x:nat) (Hx : x = 0) |- x = x ]] => reflexivity).
+  match_goal with [[ (x:nat) (Hx : x = 0) |- x = x ]] => reflexivity end.
 Qed.
 
 Example apply_tactic (a b : nat) : a > b -> S a > S b.

--- a/tests/test_goal_match.v
+++ b/tests/test_goal_match.v
@@ -4,10 +4,10 @@ Goal forall x : nat, forall y : bool, True.
 MProof.
 intros x y.
 (* works *)
-match_goal ([[ (x : nat) (y : bool) |- _ ]] => idtac).
-match_goal ([[ (y : bool) (y : nat) |- _ ]] => idtac).
+match_goal with [[ (x : nat) (y : bool) |- _ ]] => idtac end.
+match_goal with [[ (y : bool) (y : nat) |- _ ]] => idtac end.
 (* it should fail *)
-Fail match_goal ([[ (x : nat) (y : nat) |- _ ]] => idtac).
+Fail match_goal with [[ (x : nat) (y : nat) |- _ ]] => idtac end.
 exact I.
 Qed.
 
@@ -15,12 +15,12 @@ Goal forall (x : nat) (H : x > 0) (y : bool), True.
 MProof.
 intros x H y.
 (* works *)
-match_goal ([[ (x : nat) (y : bool) |- _ ]] => idtac).
-match_goal ([[ (y : bool) (y : nat) |- _ ]] => idtac).
-match_goal ([[ (z : nat) (Q : z > 0) |- _ ]] => idtac).
-match_goal ([[ (z : nat) (w : bool) (Q : z > 0) |- _ ]] => idtac).
-match_goal ([[ (w : bool) (z : nat) (Q : z > 0) |- _ ]] => idtac).
-match_goal ([[ (Q : x > 0) (z : nat) |- _ ]] => idtac).
+match_goal with [[ (x : nat) (y : bool) |- _ ]] => idtac end.
+match_goal with [[ (y : bool) (y : nat) |- _ ]] => idtac end.
+match_goal with [[ (z : nat) (Q : z > 0) |- _ ]] => idtac end.
+match_goal with [[ (z : nat) (w : bool) (Q : z > 0) |- _ ]] => idtac end.
+match_goal with [[ (w : bool) (z : nat) (Q : z > 0) |- _ ]] => idtac end.
+match_goal with [[ (Q : x > 0) (z : nat) |- _ ]] => idtac end.
 
 (* it should fail *)
 Fail match_goal ([[ (x : nat) (y : nat) |- _ ]] => idtac).
@@ -30,25 +30,35 @@ Qed.
 Goal forall (x : nat) (H : x > 0) (y : bool), x = x.
 MProof.
 intros x H y.
-match_goal ([[ (Q : x > 0) (z : nat) |- x = z ]] => reflexivity).
+match_goal with [[ (Q : x > 0) (z : nat) |- x = z ]] => reflexivity end.
 Qed.
 
 Goal forall (x : nat) (H : x > 0) (y : bool), x = x.
 MProof.
 intros x H y.
-match_goal ([[? a | (Q : a > 0) (z : nat) |- a = z ]] => reflexivity).
+match_goal with [[? a | (Q : a > 0) (z : nat) |- a = z ]] => reflexivity end.
 Qed.
 
 Goal forall (x : nat) (H : x > 0) (y : bool), 0 + x = x.
 MProof.
 intros x H y.
-match_goal ([[? a | (Q : a > 0) (z : nat) |- a = z ]] => apply (eq_refl a)).
+match_goal with [[? a | (Q : a > 0) (z : nat) |- a = z ]] => apply (eq_refl a) end.
+Qed.
+
+Goal forall (x : nat) (H : x > 0) (y : bool), 0 + x = x.
+MProof.
+intros x H y.
+match_goal with
+| [[? a |- a = a + a ]] => idtac
+| [[? a | (Q : a > 0) (z : nat) |- a = z ]] => apply (eq_refl a)
+| [[? a : nat |- a = a ]] => fail (Failure "should not happen")
+end.
 Qed.
 
 Goal forall (x : nat) (H : x > 0) (y : bool), 0 + x = x.
 MProof.
 intros x H y.
 (* a is instantiated with x, and then when matching x with 0 + x it fails (as it should) *)
-Fail match_goal_nored ([[? a | (Q : a > 0) (z : nat) |- a = z ]] => apply (eq_refl a)).
-match_goal_nored ([[? a | (Q : a > 0) (z : nat) |- 0 + a = z ]] => apply (eq_refl a)).
+Fail match_goal_nored with [[? a | (Q : a > 0) (z : nat) |- a = z ]] => apply (eq_refl a) end.
+match_goal_nored with [[? a | (Q : a > 0) (z : nat) |- 0 + a = z ]] => apply (eq_refl a) end.
 Qed.

--- a/theories/Mtac2.v
+++ b/theories/Mtac2.v
@@ -388,22 +388,23 @@ Delimit Scope metaCoq_pattern_scope with metaCoq_pattern.
 
 Notation "'with' | p1 | .. | pn 'end'" :=
   ((@cons (pattern _ _ _) p1%metaCoq_pattern (.. (@cons (pattern _ _ _) pn%metaCoq_pattern nil) ..)))
-    (at level 91, p1 at level 210, pn at level 210).
+    (at level 91, p1 at level 210, pn at level 210) : mmatch_with.
 Notation "'with' p1 | .. | pn 'end'" :=
   ((@cons (pattern _ _ _) p1%metaCoq_pattern (.. (@cons (pattern _ _ _) pn%metaCoq_pattern nil) ..)))
-    (at level 91, p1 at level 210, pn at level 210).
+    (at level 91, p1 at level 210, pn at level 210) : mmatch_with.
 
-Notation "'mmatch' x ls" := (@tmatch _ (fun _=>_) x ls)
-  (at level 90, ls at level 91) : Mtac_scope.
-Notation "'mmatch' x 'return' 'M' p ls" := (@tmatch _ (fun x=>p) x ls)
-  (at level 90, ls at level 91) : Mtac_scope.
-Notation "'mmatch' x 'as' y 'return' 'M' p ls" := (@tmatch _ (fun y=>p) x ls)
-  (at level 90, ls at level 91) : Mtac_scope.
+Delimit Scope mmatch_with with mmatch_with.
 
+Notation "'mmatch' x ls" := (@tmatch _ (fun _=>_) x ls%mmatch_with)
+  (at level 90, ls at level 91) : Mtac_scope.
+Notation "'mmatch' x 'return' 'M' p ls" := (@tmatch _ (fun x=>p) x ls%mmatch_with)
+  (at level 90, ls at level 91) : Mtac_scope.
+Notation "'mmatch' x 'as' y 'return' 'M' p ls" := (@tmatch _ (fun y=>p) x ls%mmatch_with)
+  (at level 90, ls at level 91) : Mtac_scope.
 
 Notation "'mtry' a ls" :=
   (ttry a (fun e=>
-    (@tmatch _ (fun _=>_) e (app ls (cons ([? x] x=>raise x)%metaCoq_pattern nil)))))
+    (@tmatch _ (fun _=>_) e (app ls%mmatch_with (cons ([? x] x=>raise x)%metaCoq_pattern nil)))))
     (at level 82, a at level 100, ls at level 91, only parsing).
 
 Definition Cevar (A : Type) (ctx : list Hyp) : M A := evar A (Some ctx).


### PR DESCRIPTION
For example
```coq
match_goal with
| [[? a |- a = a + a ]] => idtac
| [[? a | (Q : a > 0) (z : nat) |- a = z ]] => apply (eq_refl a)
| [[? a : nat |- a = a ]] => fail (Failure "should not happen")
end.
```