### PR TITLE
Allow matching on arbitrary terms when specifying `return`  type.

### DIFF
--- a/theories/Base.v
+++ b/theories/Base.v
@@ -428,7 +428,7 @@ Module notations.
     (@mmatch' _ (fun _ => _) x ls%with_pattern)
     (at level 90, ls at level 91) : M_scope.
   Notation "'mmatch' x 'return' 'M' p ls" :=
-    (@mmatch' _ (fun x => p%type) x ls%with_pattern)
+    (@mmatch' _ (fun _ => p%type) x ls%with_pattern)
     (at level 90, ls at level 91) : M_scope.
   Notation "'mmatch' x 'as' y 'return' 'M' p ls" :=
     (@mmatch' _ (fun y => p%type) x ls%with_pattern)


### PR DESCRIPTION
(The commit message was botched a bit)

This PR changes `mmatch x return M ..` to allow for abitrary terms in `x`. Previously x was used as (useless?) binder in a function and thus had to be a name. Now `mmatch` mirrors Coq's `match`. If the return type is dependent, `as` must be used.

As far as I can tell, this does not introduce new test failures.