### PR TITLE
Avoid construncting `meq` terms by using CPS `unify` primitive.

### DIFF
--- a/src/mConstr.ml
+++ b/src/mConstr.ml
@@ -57,7 +57,7 @@ type 'a mconstr_head =
   | Mdestcase : (arg_type * arg_any) mconstr_head
   | Mconstrs : (arg_type * arg_any) mconstr_head
   | Mmakecase : (arg_case) mconstr_head
-  | Munify : (arg_type * arg_any * arg_any * arg_any) mconstr_head
+  | Munify : (arg_type * arg_type * arg_any * arg_any * arg_any * arg_fun * arg_fun) mconstr_head
   | Munify_univ : (arg_type * arg_type * arg_any) mconstr_head
   | Mget_reference : (arg_string) mconstr_head
   | Mget_var : (arg_string) mconstr_head
@@ -117,7 +117,7 @@ let num_args_of_mconstr (type a) (mh : a mconstr_head) =
   | Mdestcase -> 2
   | Mconstrs -> 2
   | Mmakecase -> 1
-  | Munify -> 4
+  | Munify -> 7
   | Munify_univ -> 3
   | Mget_reference -> 1
   | Mget_var -> 1
@@ -266,7 +266,7 @@ let name_makecase = constant_of_string "makecase"
 (* let mkmakecase = mkconstr name_makecase *)
 let ismakecase = isconstant name_makecase
 
-let name_unify = constant_of_string "unify"
+let name_unify = constant_of_string "unify_cnt"
 (* let mkunify = mkconstr name_unify *)
 let isunify = isconstant name_unify
 
@@ -576,7 +576,7 @@ let mconstr_of (type a) args (h : a mconstr_head) =
   | Mmakecase ->
       MConstr (Mmakecase, (args 0))
   | Munify ->
-      MConstr (Munify, (args 0, args 1, args 2, args 3))
+      MConstr (Munify, (args 0, args 1, args 2, args 3, args 4, args 5, args 6))
   | Munify_univ ->
       MConstr (Munify_univ, (args 0, args 1, args 2))
   | Mget_reference ->

--- a/src/mConstr.mli
+++ b/src/mConstr.mli
@@ -54,7 +54,7 @@ type 'a mconstr_head =
   | Mdestcase : (arg_type * arg_any) mconstr_head
   | Mconstrs : (arg_type * arg_any) mconstr_head
   | Mmakecase : (arg_case) mconstr_head
-  | Munify : (arg_type * arg_any * arg_any * arg_any) mconstr_head
+  | Munify : (arg_type * arg_type * arg_any * arg_any * arg_any * arg_fun * arg_fun) mconstr_head
   | Munify_univ : (arg_type * arg_type * arg_any) mconstr_head
   | Mget_reference : (arg_string) mconstr_head
   | Mget_var : (arg_string) mconstr_head

--- a/src/run.ml
+++ b/src/run.ml
@@ -1307,19 +1307,15 @@ let rec run' ctxt (vms : vm list) =
                               efail (E.mkNotAList sigma env l)
                         end
 
-                    | MConstr (Munify, (a, x, y, uni)) ->
-                        let a, x, y, uni = to_econstr a, to_econstr x, to_econstr y, to_econstr uni in
-                        let sigma, feqT = CoqEq.mkType sigma env a x y in
+                    | MConstr (Munify, (_,_, uni, x, y, ts, tf)) ->
+                        let x, y, uni = to_econstr x, to_econstr y, to_econstr uni in
                         begin
                           let r = UnificationStrategy.unify None sigma env uni Reduction.CONV x y in
                           match r with
                           | Evarsolve.Success sigma, _ ->
-                              let sigma, feq = CoqEq.mkEqRefl sigma env a x in
-                              let sigma, someFeq = CoqOption.mkSome sigma env feqT feq in
-                              ereturn sigma someFeq
+                              (run'[@tailcall]) {ctxt with sigma = sigma} (Code ts :: vms)
                           | _, _ ->
-                              let sigma, none = CoqOption.mkNone sigma env feqT in
-                              ereturn sigma none
+                              (run'[@tailcall]) ctxt (Code tf :: vms)
                         end
 
                     | MConstr (Munify_univ, (x, y, uni)) ->

--- a/theories/intf/M.v
+++ b/theories/intf/M.v
@@ -181,11 +181,14 @@ Definition constrs: forall{A: Type} (a: A), t (mprod dyn (mlist dyn)).
 Definition makecase: forall(C: Case), t dyn.
   make. Qed.
 
-(** [munify x y r] uses reduction strategy [r] to equate [x] and [y].
+(** [unify r x y ts tf] uses reduction strategy [r] to equate [x] and [y].
+    If unification succeeds, it will run [ts].
+    Otherwise, if unification fails, [tf] is executed instead.
     It uses convertibility of universes, meaning that it fails if [x]
     is [Prop] and [y] is [Type]. If they are both types, it will
     try to equate its leveles. *)
-Definition unify {A: Type} (x y: A) : Unification -> t (moption (meq x y)).
+
+Definition unify_cnt {A: Type} {B: A -> Type} (U:Unification) (x y : A) : t (B y) -> t (B x) -> t (B x).
   make. Qed.
 
 (** [munify_univ A B r] uses reduction strategy [r] to equate universes
@@ -321,6 +324,11 @@ Definition fapp {A:Type} {B:Type} (f : t (A -> B)) (x : t A) : t B :=
 
 Definition Cevar (A : Type) (ctx : mlist Hyp) : t A := gen_evar A (mSome ctx).
 Definition evar (A : Type) : t A := gen_evar A mNone.
+
+Definition unify {A : Type} (x y : A) (U : Unification) : t (moption (x =m= y)) :=
+  unify_cnt (B:=fun x => moption (meq x y)) U x y
+            (ret (mSome (@meq_refl _ y)))
+            (ret mNone).
 
 
 Definition raise {A:Type} (e: Exception): t A :=


### PR DESCRIPTION
This is a proof-of-concept implementation of a CPS version of the `unify` primitive in line with #84. 

My measurements show a 3x-4x performance gains on the whole of `timings/*.v` but they might be wrong. In any case, this is not going to be slower than what we have now. (We really need timing CI infrastructure!)

Sadly, Iris is not affected at all. Not enough `mmatch` going on there to make performance improvements to `unify` worth anything.

Also, an ugly part of this is that I cannot use exceptions to implement the failure case – for that, I would need to be able to `unify` the exception given to me in the handler by `mtry` with whatever exception I pick in run.ml but this is in the implementation of `unify` so that won't work.. For now, I use a second continuation to handle the failure case. 

Also, all continuations here have arity zero. I don't know a term for that specific case so I just keep calling them continuations.