### PR TITLE
Adapt to coq/coq#7558.

### DIFF
--- a/src/metaCoqInit.ml4
+++ b/src/metaCoqInit.ml4
@@ -126,11 +126,11 @@ let () =
     name  = proof_mode_identifier ;
     set   =
       begin fun () ->
-        Pcoq.set_command_entry mproof_mode
+        Pvernac.set_command_entry mproof_mode
       end ;
     reset =
       begin fun () ->
-       Pcoq.set_command_entry Pcoq.Vernac_.noedit_mode
+       Pvernac.(set_command_entry Vernac_.noedit_mode)
       end
   }
 


### PR DESCRIPTION
Trivial renaming of the vernacular parsing entry point.

Not to merge until Coq devs ask for it.