### PR TITLE
Another fix for https://github.com/coq/coq/pull/8064

### DIFF
--- a/theories/tactics/IntroPatt.v
+++ b/theories/tactics/IntroPatt.v
@@ -1,3 +1,4 @@
+Require Import Coq.Strings.String.
 From Mtac2 Require Import List Base.
 From Mtac2.tactics Require Import TacticsBase Tactics ImportedTactics.
 Import Mtac2.lib.List.ListNotations.


### PR DESCRIPTION
This is required for compatibility with
https://github.com/coq/coq/pull/8064, where prim token notations no
longer follow `Require`, but instead follow `Import`.

c.f. https://github.com/coq/coq/pull/8064#issuecomment-415493362

All changes were made via
https://gist.github.com/JasonGross/5d4558edf8f5c2c548a3d96c17820169#file-fix-py