### PR TITLE
PR7819 overlay

### DIFF
--- a/src/run.ml
+++ b/src/run.ml
@@ -454,7 +454,7 @@ module UnificationStrategy = struct
     Munify.unify_match_nored;
     (fun _ ts env sigma conv_pb t1 t2->
        try
-         match evar_conv_x ts env sigma conv_pb t1 t2 with
+         match evar_conv_x (default_flags_of ts) env sigma conv_pb t1 t2 with
          | Success sigma -> Success (solve_unif_constraints_with_heuristics env sigma)
          | e -> e
        with _ -> UnifFailure (sigma, Pretype_errors.ProblemBeyondCapabilities))

--- a/tests/test_mmatch.v
+++ b/tests/test_mmatch.v
@@ -93,7 +93,7 @@ Qed.
 
 
 (* This definition fails because Coq is unable to find the returning type*)
-Fail Definition test (t : nat)  :=
+Definition test (t : nat)  :=
   mmatch t with
   | 0 => ret (eq_refl 0)
   end.


### PR DESCRIPTION
Evarconv's interface changes. To be merged when coq/coq#7819 is merged, together with the unicoq overlay PR unicoq/unicoq#14.