### PR TITLE
[coq] Port to coqpp preprocessor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@
 .dir-locals.el
 
 # output of tests
+src/metaCoqInit.ml
+src/metaCoqTactic.ml

--- a/_CoqProject
+++ b/_CoqProject
@@ -4,7 +4,7 @@ CAMLDEBUG = "-g"
 -R theories Mtac2
 -Q tests Mtac2Tests
 -arg -bt
-src/metaCoqInit.ml4
+src/metaCoqInit.mlg
 src/metaCoqInstr.mli
 src/constrs.ml
 src/constrs.mli
@@ -19,7 +19,7 @@ src/run.ml
 src/run.mli
 src/metaCoqInterp.ml
 src/metaCoqInterp.mli
-src/metaCoqTactic.ml4
+src/metaCoqTactic.mlg
 src/MetaCoqPlugin.mlpack
 theories/lib/Logic.v
 theories/lib/Specif.v

--- a/src/metaCoqInit.mlg
+++ b/src/metaCoqInit.mlg
@@ -1,3 +1,5 @@
+{
+
 (** This module initializes the plugin (parser extension, callbacks, …). *)
 
 open Pcoq  (* required by Camlp5 *)
@@ -11,7 +13,12 @@ open Pcoq  (* required by Camlp5 *)
    Remark: We should add a "How-to write your plugin" section in Coq manual.
 
 *)
+
+}
+
 DECLARE PLUGIN "MetaCoq"
+
+{
 
 (** Defines the parser of the proof mode for MetaCoq.
 
@@ -86,19 +93,22 @@ let mproof_instr : MetaCoqInstr.mproof_instr Pcoq.Entry.t =
     Finally, we do not produce any semantic value for the moment.
 
 *)
+}
 
-VERNAC mproof_mode EXTEND MProofInstr
-  [ - mproof_instr(_instr) ] => [ let open Vernacexpr in VtProofStep {parallel = `No; proof_block_detection = None}, VtLater ] ->
-  [ MetaCoqInterp.interp_proof_constr _instr ]
+VERNAC { mproof_mode } EXTEND MProofInstr
+| [ mproof_instr(_instr) ] =>
+  { let open Vernacexpr in VtProofStep {parallel = `No; proof_block_detection = None}, VtLater } ->
+  { MetaCoqInterp.interp_proof_constr _instr }
 END
 
 (** The parsing rule for the non terminal [mproof_instr]. *)
-GEXTEND Gram
+GRAMMAR EXTEND Gram
 GLOBAL: mproof_instr;
   mproof_instr :
-    [[ c=Pcoq.Constr.operconstr ; "." -> MetaCoqInstr.MetaCoq_constr c ]];
+    [[ c=Pcoq.Constr.operconstr ; "." -> { MetaCoqInstr.MetaCoq_constr c } ]];
 END
 
+{
 (** Initialize the proof mode MProof for MetaCoq. *)
 
 (** The following identifiers must be globally unique. They are used
@@ -167,11 +177,14 @@ let () =
      interpretation function is registered in Vernacinterp and called
      in Vernacentries.interp.
 *)
+
+}
+
 VERNAC COMMAND EXTEND MProofCommand
-  [ "MProof" ]
-  => [ Vernacexpr.VtProofMode proof_mode_identifier, Vernacexpr.VtNow  ]
-  -> [ MetaCoqInterp.interp_mproof_command () ]
+| [ "MProof" ]
+  => { Vernacexpr.(VtProofMode proof_mode_identifier), Vernacexpr.VtNow }
+  -> { MetaCoqInterp.interp_mproof_command () }
 | [ "MQed" ]
-  => [ Vernacexpr.VtProofMode proof_mode_identifier, Vernacexpr.VtNow  ]
-  -> [ MetaCoqInterp.end_proof () ]
+  => { Vernacexpr.(VtProofMode proof_mode_identifier), Vernacexpr.VtNow  }
+  -> { MetaCoqInterp.end_proof () }
 END

--- a/src/metaCoqTactic.mlg
+++ b/src/metaCoqTactic.mlg
@@ -1,12 +1,14 @@
-(*i camlp4deps: "parsing/grammar.cma" i*)
-(*i camlp4use: "pa_extend.cmo" i*)
-
+{
 open Ltac_plugin
 open MetaCoqInterp
 open Stdarg
 open Pcoq.Constr
 
+}
+
 DECLARE PLUGIN "MetaCoqPlugin"
+
+{
 
 let print_mtac_type _ _ _ _ = Pp.mt ()
 
@@ -17,23 +19,25 @@ let subst_mtac_type subst r =
   let ty, r = r in
   (ty, fst (Globnames.subst_global subst r))
 
+}
+
 ARGUMENT EXTEND mtac_type
-  PRINTED BY print_mtac_type
+  PRINTED BY { print_mtac_type }
 
-  INTERPRETED BY interp_mtac_type
-  GLOBALIZED BY glob_mtac_type
-  SUBSTITUTED BY subst_mtac_type
+  INTERPRETED BY { interp_mtac_type }
+  GLOBALIZED BY { glob_mtac_type }
+  SUBSTITUTED BY { subst_mtac_type }
 
-| [ global(l) ] -> [ l ]
+| [ global(l) ] -> { [ l ] }
 END
 
 TACTIC EXTEND mrun
-  | [ "mrun_static" mtac_type(c) ] -> [ MetaCoqRun.run_tac_constr (StaticallyChecked c) ]
-  | [ "mrun" uconstr(c) ] -> [ MetaCoqRun.run_tac_constr (DynamicallyChecked c) ]
+  | [ "mrun_static" mtac_type(c) ] -> { MetaCoqRun.run_tac_constr (StaticallyChecked c) }
+  | [ "mrun" uconstr(c) ] -> { MetaCoqRun.run_tac_constr (DynamicallyChecked c) }
 END
 
 VERNAC COMMAND EXTEND MtacDo CLASSIFIED AS SIDEFF
-  | [ "Mtac" "Do" uconstr(c) ] -> [
+  | [ "Mtac" "Do" uconstr(c) ] -> {
       MetaCoqRun.run_cmd c
-  ]
+  }
 END


### PR DESCRIPTION
The ml4 preprocessor is deprecated and may be removed in 8.10.

Porting to `coqpp` is routine.