### PR TITLE
[coq] Tweak for coq/coq#9150

### DIFF
--- a/src/cClosure_copy.ml
+++ b/src/cClosure_copy.ml
@@ -853,7 +853,7 @@ let eta_expand_ind_stack env ind m s (f, s') =
       let pars = mib.Declarations.mind_nparams in
       let right = fapp_stack (f, s') in
       let (depth, args, s) = strip_update_shift_app m s in
-      (** Try to drop the params, might fail on partially applied constructors. *)
+      (* Try to drop the params, might fail on partially applied constructors. *)
       let argss = try_drop_parameters depth pars args in
       let hstack = Array.map (fun p ->
         { norm = Red; (* right can't be a constructor though *)


### PR DESCRIPTION
I am not sure why this happens but after coq/coq#9150 mtac2 fails to
build with a warning 50 error.

Fix is trivial and backwards compatible, please apply.