### PR TITLE
Add better names for `Sort`s; introduce notation.

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -4,7 +4,7 @@ CAMLDEBUG = "-g"
 -I src
 -R theories Mtac2
 -Q tests Mtac2Tests
--arg -bt
+-arg "-w -unrecognized-unicode"
 src/metaCoqInit.mlg
 src/metaCoqInstr.mli
 src/constrs.ml

--- a/examples/tauto.v
+++ b/examples/tauto.v
@@ -156,7 +156,7 @@ Module Mtac_V4.
 
   Definition promote_uninst_evar {X} {A} (x : X) (a : A *m mlist (goal _)) : ttac (A) :=
     let '(m: a, gs) := a in
-    mif is_evar x then ret (m: a, AnyMetavar SType x :m: gs) else ret (m: a, gs).
+    mif is_evar x then ret (m: a, AnyMetavar Typeₛ x :m: gs) else ret (m: a, gs).
 
   Definition has_open_subgoals {A} (a : A *m mlist (goal gs_any)) : M bool :=
     ret (match msnd a with [m:] => true | _ => false end).

--- a/src/constrs.ml
+++ b/src/constrs.ml
@@ -458,27 +458,27 @@ end
 module CoqSort = struct
   open UConstrBuilder
 
-  let sType = from_string "Mtac2.intf.Sorts.S.SType"
-  let sProp = from_string "Mtac2.intf.Sorts.S.SProp"
+  let sType = from_string "Mtac2.intf.Sorts.S.Type_sort"
+  let sProp = from_string "Mtac2.intf.Sorts.S.Prop_sort"
 
   let mkSType env sigma = build_app sType sigma env [||]
   let mkSProp env sigma = build_app sProp sigma env [||]
 
   exception NotASort
 
-  type sort = SProp | SType
+  type sort = Prop_sort | Type_sort
 
   let from_coq sigma env cterm =
     match from_coq sProp (env, sigma) cterm with
-    | Some args -> SProp
+    | Some args -> Prop_sort
     | None ->
         match from_coq sType (env, sigma) cterm with
         | None -> raise NotASort
-        | Some args -> SType
+        | Some args -> Type_sort
 
   let to_coq sigma env = function
-    | SProp -> mkSProp env sigma
-    | SType -> mkSType env sigma
+    | Prop_sort -> mkSProp env sigma
+    | Type_sort -> mkSType env sigma
 
 
 end

--- a/src/constrs.mli
+++ b/src/constrs.mli
@@ -165,7 +165,7 @@ module CoqSort : sig
   val mkSType : Environ.env -> Evd.evar_map -> Evd.evar_map * EConstr.t
   val mkSProp : Environ.env -> Evd.evar_map -> Evd.evar_map * EConstr.t
   exception NotASort
-  type sort = SProp | SType
+  type sort = Prop_sort | Type_sort
   val from_coq : Evd.evar_map -> Environ.env -> EConstr.t -> sort
   val to_coq :
     Evd.evar_map -> Environ.env -> sort -> Evd.evar_map * EConstr.t

--- a/src/run.ml
+++ b/src/run.ml
@@ -1054,8 +1054,8 @@ let declare_mind env sigma params sigs mut_constrs =
       let (ind_tele, ind_ty) = CoqSigT.from_coq sigma env (strip_lambdas sigma ind_sig  n_params) in
       let sigma, n_ind_args, ind_arity = mTele_to_foralls sigma env ind_tele ind_ty (fun sigma _ t ->
         match CoqSort.from_coq sigma env t with
-        | SProp -> sigma, mkProp
-        | SType ->
+        | Prop_sort -> sigma, mkProp
+        | Type_sort ->
             let sigma, univ = Evd.new_univ_variable (Evd.UnivFlexible false) sigma in
             sigma, mkType univ
       ) in

--- a/tests/DepDestruct.v
+++ b/tests/DepDestruct.v
@@ -67,7 +67,7 @@ MProof.
   - intro nxP &> split &> [m:intros &> contradiction | intros &> discriminate].
 Qed.
 
-  Example reflect_reflect P : ITele (SType) := iTele (fun b=>@iBase SType (reflect P b)).
+  Example reflect_reflect P : ITele (Typeₛ) := iTele (fun b=>@iBase Typeₛ (reflect P b)).
 
   Example reflect_RTrue P : CTele (reflect_reflect P) :=
     (cProd (fun p : P=>@cBase _ (reflect_reflect _) (aTele true aBase) (RTrue P p))).
@@ -78,21 +78,21 @@ Qed.
   Example reflect_args P b : ATele (reflect_reflect P) :=
     aTele b aBase.
 
-  Example bla P : RTele SProp (reflect_reflect P) :=
+  Example bla P : RTele Propₛ (reflect_reflect P) :=
     Eval simpl in (fun b=>(fun _=>P <-> b = true)).
   Example bla_branch P := Eval simpl in branch_of_CTele (bla P) (reflect_RTrue P).
 
 
   Example bla_RTele P b (r : reflect P b) : RTele _ _ :=
-    Eval compute in M.eval (abstract_goal (rsort := SProp) ((P <-> b = true)) (reflect_args P b) r).
+    Eval compute in M.eval (abstract_goal (rsort := Propₛ) ((P <-> b = true)) (reflect_args P b) r).
 
   Example bla_goals P b r : mlist dyn :=
     Eval compute in
-      mmap (fun cs => Dyn (branch_of_CTele (rsort := SProp) (bla_RTele P b r) cs))
+      mmap (fun cs => Dyn (branch_of_CTele (rsort := Propₛ) (bla_RTele P b r) cs))
            [m: reflect_RTrue P | reflect_RFalse P].
 
   Example reflectP_it : ITele _ :=
-    iTele (fun P => iTele (fun b => iBase (sort := SType) (reflect P b))).
+    iTele (fun P => iTele (fun b => iBase (sort := Typeₛ) (reflect P b))).
   Program Example reflectP_RTrue : CTele reflectP_it :=
     cProd (fun P => cProd (fun p => (cBase (aTele _ (aTele _ aBase)) (@RTrue P p)))).
   Program Example reflectP_RFalse : CTele reflectP_it :=
@@ -103,7 +103,7 @@ Qed.
   Example reflect_app P b := Eval compute in ITele_App (reflect_args P b).
 
   Example blaP_RTele P b r : RTele _ _ :=
-    Eval compute in M.eval (abstract_goal (rsort := SProp) ((P <-> b = true)) (reflectP_args P b) r).
+    Eval compute in M.eval (abstract_goal (rsort := Propₛ) ((P <-> b = true)) (reflectP_args P b) r).
 
   Example blaP_goals P b r : mlist dyn :=
     Eval compute in
@@ -125,7 +125,7 @@ Qed.
   Goal forall P b, reflect P b -> P <-> b = true.
   Proof.
     intros P b r.
-    pose (rG := (M.eval (abstract_goal (rsort := SType) (P <-> b = true) (reflect_args P b) r)) : RTele _ _).
+    pose (rG := (M.eval (abstract_goal (rsort := Typeₛ) (P <-> b = true) (reflect_args P b) r)) : RTele _ _).
     cbn delta -[RTele] in rG.
     assert (T : branch_of_CTele rG (reflect_RTrue P)).
     { now firstorder. }
@@ -165,7 +165,7 @@ Fixpoint unfold_funs {A} (t: A) (n: nat) {struct n} : M A :=
 Goal forall P b, reflect P b -> P <-> b = true.
 MProof.
   intros P b r.
-  mpose (rG := abstract_goal (rsort := SProp) (P <-> b = true) (reflect_args P b)  r).
+  mpose (rG := abstract_goal (rsort := Propₛ) (P <-> b = true) (reflect_args P b)  r).
   simpl.
   assert (T : branch_of_CTele rG (reflect_RTrue P)).
   { simpl. cintros x {- split&> [m:cintros xP {- reflexivity -} | cintros notP {- assumption -}] -}. (* it doesn't work if intros is put outside *) }
@@ -196,13 +196,13 @@ Module VectorExample.
 Require Import Vector.
 Goal forall n (v : t nat n), n = Coq.Lists.List.length (to_list v).
 Proof.
-  pose (it := iTele (fun n => @iBase (SType) (t nat n))).
-  pose (vnil := ((@cBase SType it (aTele 0 aBase) (nil nat))) : CTele it).
-  pose (vcons := (cProd (fun a => cProd (fun n => cProd (fun (v : t nat n) => (@cBase SType it (aTele (S n) aBase) (cons _ a _ v)))))) : CTele it).
+  pose (it := iTele (fun n => @iBase (Typeₛ) (t nat n))).
+  pose (vnil := ((@cBase Typeₛ it (aTele 0 aBase) (nil nat))) : CTele it).
+  pose (vcons := (cProd (fun a => cProd (fun n => cProd (fun (v : t nat n) => (@cBase Typeₛ it (aTele (S n) aBase) (cons _ a _ v)))))) : CTele it).
   fix f 2.
   intros n v.
   pose (a := (aTele n (aBase)) : ATele it).
-  pose (rt := M.eval (abstract_goal (rsort := SProp) (n = Coq.Lists.List.length (to_list v)) a v)).
+  pose (rt := M.eval (abstract_goal (rsort := Propₛ) (n = Coq.Lists.List.length (to_list v)) a v)).
   simpl in vcons.
   cbn beta iota zeta delta -[RTele] in rt.
   assert (N : branch_of_CTele rt vnil).

--- a/tests/declare.v
+++ b/tests/declare.v
@@ -119,7 +119,7 @@ Definition typ_of {A : Type} (a : A) := A.
 Import TeleNotation.
 Notation P := [tele (T : Type) (k : nat)].
 Module M1.
-  Notation I2 := (m: "blubb__"%string; fun T k => mexistT (MTele_ConstT _) ([tele _ : k = k]) (fun _ => S.SProp)).
+  Notation I2 := (m: "blubb__"%string; fun T k => mexistT (MTele_ConstT _) ([tele _ : k = k]) (fun _ => Propₛ)).
   Definition mind_test := (M.declare_mind P ([m: I2])).
   Eval cbv beta iota fix delta [mfold_right typ_of] in typ_of mind_test.
   (* Eval cbv beta iota fix delta [mfold_right typ_of] in *)
@@ -142,7 +142,7 @@ Module M1.
 End M1.
 
 Module M2.
-  Notation I2 := (m: "blubb__"%string; fun T k => mexistT (MTele_ConstT _) ([tele _ : k = k]) (fun _ => S.SProp)).
+  Notation I2 := (m: "blubb__"%string; fun T k => mexistT (MTele_ConstT _) ([tele _ : k = k]) (fun _ => Propₛ)).
   Definition mind_test := (M.declare_mind P ([m: I2])).
   Eval cbv beta iota fix delta [mfold_right typ_of] in typ_of mind_test.
   (* Eval cbv beta iota fix delta [mfold_right typ_of] in *)
@@ -156,7 +156,7 @@ Module M2.
                  mexistT
                    _
                    (mTele (fun t : T => mBase))
-                   (S.Fun (sort:=S.SType) (fun t => ((mexistT _ eq_refl tt))))
+                   (S.Fun (sort:=Typeₛ) (fun t => ((mexistT _ eq_refl tt))))
              )
           ];
           tt)
@@ -173,8 +173,8 @@ End M2.
 
 Module M3.
 
-Notation I1 := (m: "bla__"%string; fun T k => mexistT (MTele_ConstT _) ([tele]) (S.SType)).
-Notation I2 := (m: "blubb__"%string; fun T k => mexistT (MTele_ConstT _ ) ([tele]) (S.SProp)).
+Notation I1 := (m: "bla__"%string; fun T k => mexistT (MTele_ConstT _) ([tele]) (Typeₛ)).
+Notation I2 := (m: "blubb__"%string; fun T k => mexistT (MTele_ConstT _ ) ([tele]) (Propₛ)).
 Definition mind_test := (M.declare_mind P ([m: I1 |  I2])).
 Eval cbv beta iota fix delta [mfold_right typ_of] in typ_of mind_test.
 (* Eval cbv beta iota fix delta [mfold_right typ_of] in *)
@@ -188,7 +188,7 @@ Definition testprog :=
                  mexistT
                    _
                    (mTele (fun t : I2 T k => mBase))
-                   (S.Fun (sort:=S.SType) (fun t => tt))
+                   (S.Fun (sort:=Typeₛ) (fun t => tt))
              )
           ];
           [m:
@@ -196,7 +196,7 @@ Definition testprog :=
                  mexistT
                    _
                    (mTele (fun t : I1 T k => mBase))
-                   (S.Fun (sort:=S.SType) (fun t => tt))
+                   (S.Fun (sort:=Typeₛ) (fun t => tt))
              )
           ];
         tt)
@@ -210,8 +210,8 @@ Eval cbn in ltac:(mrun(
 End M3.
 
 Module M4.
-  Notation I1 := (m: "bla__"%string; fun T k => mexistT (MTele_ConstT _) ([tele x y : nat]) (fun x y => S.SType)).
-  Notation I2 := (m: "blubb__"%string; fun T k => mexistT (MTele_ConstT _) ([tele _ : k = k]) (fun _ => S.SProp)).
+  Notation I1 := (m: "bla__"%string; fun T k => mexistT (MTele_ConstT _) ([tele x y : nat]) (fun x y => Typeₛ)).
+  Notation I2 := (m: "blubb__"%string; fun T k => mexistT (MTele_ConstT _) ([tele _ : k = k]) (fun _ => Propₛ)).
   Definition mind_test := (M.declare_mind P ([m: I1 |  I2])).
   Eval cbv beta iota fix delta [mfold_right typ_of] in typ_of mind_test.
   (* Eval cbv beta iota fix delta [mfold_right typ_of] in *)
@@ -225,7 +225,7 @@ Module M4.
                    mexistT
                      _
                      (mTele (fun t : I2 T k eq_refl => mBase))
-                     (S.Fun (sort:=S.SType) (fun t => (mexistT _ 1 (mexistT _ 2 tt))))
+                     (S.Fun (sort:=Typeₛ) (fun t => (mexistT _ 1 (mexistT _ 2 tt))))
                )
             ];
           mnil;

--- a/tests/ssrpattern.v
+++ b/tests/ssrpattern.v
@@ -15,7 +15,7 @@ Import M.notations.
 (* abstract _from_sort and _from_term *)
 Goal True->True.
 MProof.
-  opf <- T.abstract_from_sort Sorts.S.SProp 3 (3+3 = 6);
+  opf <- T.abstract_from_sort Propₛ 3 (3+3 = 6);
   match opf with
   | mSome f=> M.print_term f
   | mNone => M.failwith "abstract failed!"

--- a/tests/test_mmatch.v
+++ b/tests/test_mmatch.v
@@ -177,11 +177,11 @@ Proof. Fail reflexivity. Abort.
 From Mtac2 Require Import Sorts.
 Mtac Do ((fun (T : Type) =>
             mmatch T with [¿ s] [? (T : s)] (T : Type) =u>
-              M.unify_or_fail UniMatchNoRed s S.SProp;; M.ret I
+              M.unify_or_fail UniMatchNoRed s Propₛ;; M.ret I
           end) (True -> True)).
 Mtac Do ((fun (T : Type) =>
             mmatch T with [¿ s] [? (T : s)] (T : Type) =u>
-              M.unify_or_fail UniMatchNoRed s S.SType;; M.ret I
+              M.unify_or_fail UniMatchNoRed s Typeₛ;; M.ret I
           end) (True -> nat)).
 
 

--- a/theories/DecomposeApp.v
+++ b/theories/DecomposeApp.v
@@ -15,12 +15,12 @@ Unset Universe Minimization ToSet.
 *)
 
 (* FIX: proper error messaging *)
-Definition MTele_of (A : Type) : forall T, T -> M (msigT (MTele_Const (s:=SType) A)) :=
+Definition MTele_of (A : Type) : forall T, T -> M (msigT (MTele_Const (s:=Typeₛ) A)) :=
   let matchtele := fun T => mTele (fun _ : T => mBase) in
   let fixtele := mTele (matchtele) in
   mfix'
     (m:=fixtele)
-    (fun T (_ : T) => msigT (MTele_Const (s:=SType) A))
+    (fun T (_ : T) => msigT (MTele_Const (s:=Typeₛ) A))
     (
       fun f T =>
         mtmmatch'
@@ -31,15 +31,15 @@ Definition MTele_of (A : Type) : forall T, T -> M (msigT (MTele_Const (s:=SType)
           [m:
              (@mtpbase
                 _
-                (fun T => T -> M (msigT (MTele_Const (s:=SType) A)))
+                (fun T => T -> M (msigT (MTele_Const (s:=Typeₛ) A)))
                 A
-                (fun t : A => M.ret (mexistT (MTele_Const (s:=SType) A) mBase t))
+                (fun t : A => M.ret (mexistT (MTele_Const (s:=Typeₛ) A) mBase t))
                 UniCoq
              )
           |  (mtptele (fun (X : Type) => mtptele (fun (F : forall x : X, Type) =>
               @mtpbase
                 _
-                (fun T => T -> M (msigT (MTele_Const (s:=SType) A)))
+                (fun T => T -> M (msigT (MTele_Const (s:=Typeₛ) A)))
                 (forall x : X, F x)
                 (fun t : _ =>
                    M.nu (FreshFrom T) mNone (fun x =>
@@ -48,8 +48,8 @@ Definition MTele_of (A : Type) : forall T, T -> M (msigT (MTele_Const (s:=SType)
                                    ''(mexistT _ n T) <- f Fx tx;
                                    n' <- M.abs_fun (P:=fun _ => MTele) x n;
                                    T' <- M.coerce T;
-                                   T' <- M.abs_fun (P:=fun x => MTele_Const (s:=SType) A (n' x)) x T';
-                                   M.ret (mexistT (MTele_Const (s:=SType) A) (mTele n') T')
+                                   T' <- M.abs_fun (P:=fun x => MTele_Const (s:=Typeₛ) A (n' x)) x T';
+                                   M.ret (mexistT (MTele_Const (s:=Typeₛ) A) (mTele n') T')
                                 )
                 )
                 UniCoq
@@ -59,7 +59,7 @@ Definition MTele_of (A : Type) : forall T, T -> M (msigT (MTele_Const (s:=SType)
 
 Definition decompose_app {m : MTele} {A : Type} {B : A -> Type} {C : MTele_ConstT A m} {T: Type} (a : A) (t : T)
   :
-  M (Unification -> MTele_sort (MTele_ConstMap (si:=SType) SProp (fun a : A => M (B a)) C) -> M (B a)) :=
+  M (Unification -> MTele_sort (MTele_ConstMap (si:=Typeₛ) Propₛ (fun a : A => M (B a)) C) -> M (B a)) :=
   (
     ''(mexistT _ m' T') <- MTele_of A T t;
     M.unify m m' UniCoq;;
@@ -82,8 +82,8 @@ Notation "'<[decapp' a 'with' b ]>" :=
 
 
 Local Definition mtele_convert' {A : Type} {B : A -> Prop} {G : Type} {mt} {C : MTele_ConstT A mt} :
-  MTele_sort (MTele_ConstMap (si:=SType) SProp (fun a => G -> B a) C)
-  -> (G -> MTele_sort (MTele_ConstMap (si:=SType) SProp B C)).
+  MTele_sort (MTele_ConstMap (si:=Typeₛ) Propₛ (fun a => G -> B a) C)
+  -> (G -> MTele_sort (MTele_ConstMap (si:=Typeₛ) Propₛ B C)).
 induction mt as [|X F IHmt].
 - cbn. refine (fun x => x).
 - cbn. intros ? ? ?.
@@ -91,7 +91,7 @@ induction mt as [|X F IHmt].
 Defined.
 
 Definition decompose_app_tactic {m : MTele} {A : Type} {B : A -> Type} {C : MTele_ConstT A m} {T: Type} (a : A) (t : T) :
-  M (Unification -> MTele_sort (MTele_ConstMap (si:=SType) SProp (fun a : A => gtactic (B a)) C) -> gtactic (B a)) :=
+  M (Unification -> MTele_sort (MTele_ConstMap (si:=Typeₛ) Propₛ (fun a : A => gtactic (B a)) C) -> gtactic (B a)) :=
   (
     ''(mexistT _ m' T') <- MTele_of A T t;
     M.unify m m' UniCoq;;

--- a/theories/Pattern.v
+++ b/theories/Pattern.v
@@ -25,7 +25,7 @@ Inductive branch@{a b c+} {M : Type@{b} -> Prop} : forall {A : Type@{a}} {B : A 
 | branch_pattern {A : Type@{a}} {B : A -> Type@{b}} {y}: pattern M A B y -> @branch M A B y
 | branch_app_static {A : Type@{a}} {B : A -> Type@{b}} {y}:
     forall {m} (uni : Unification) (C : MTele_ConstT A m),
-      MTele_sort (MTele_ConstMap (si := SType) SProp (T:=A) (fun a => M (B a)) C) ->
+      MTele_sort (MTele_ConstMap (si := Typeₛ) Propₛ (T:=A) (fun a => M (B a)) C) ->
       @branch M A B y
 | branch_forallP {B : Prop -> Type@{b}} {y}:
     (forall (X : Type@{c}) (Y : X -> Prop), M (B (forall x : X, Y x))) ->

--- a/theories/ideas/DepDestruct.v
+++ b/theories/ideas/DepDestruct.v
@@ -263,8 +263,8 @@ Program Definition get_CTele_raw : forall {isort} (it : ITele isort) (nindx : na
 Definition get_CTele :=
   fun {isort} =>
     match isort as sort return forall {it : ITele sort} nindx {A : sort}, A -> M (CTele it) with
-    | SProp => get_CTele_raw (isort := SProp)
-    | SType => get_CTele_raw (isort := SType)
+    | Propₛ => get_CTele_raw (isort := Propₛ)
+    | Typeₛ => get_CTele_raw (isort := Typeₛ)
     end.
 
 
@@ -292,16 +292,16 @@ end.
 Definition get_NDCTele :=
   fun {isort} =>
     match isort as sort return forall {it : ITele sort} nindx {A : sort}, A -> M (NDCTele it) with
-    | SProp => get_NDCTele_raw (isort := SProp)
-    | SType => get_NDCTele_raw (isort := SType)
+    | Propₛ => get_NDCTele_raw (isort := Propₛ)
+    | Typeₛ => get_NDCTele_raw (isort := Typeₛ)
     end.
 
 
 (** Given a goal, it returns its sorted version *)
 Program Definition sort_goal {T : Type} : T -> M (sigT stype_of) :=
   mtmmatch_prog T as T return T -> M (sigT stype_of) with
-  | Prop =u> fun A_Prop => M.ret (existT stype_of SProp A_Prop)
-  | Type =u> fun A_Type => M.ret (existT stype_of SType A_Type)
+  | Prop =u> fun A_Prop => M.ret (existT stype_of Propₛ A_Prop)
+  | Type =u> fun A_Type => M.ret (existT stype_of Typeₛ A_Type)
   end.
 
 (* Definition sget_ITele (sort : Sort) : forall {T : sort} (ind : T), M (nat * ITele sort) := *)
@@ -333,13 +333,13 @@ Program Definition get_ITele : forall {T : Type} (ind : T), M (nat *m (sigT ITel
         M.ret (m: S n, existT _ sort (iTele f)))
     | Prop =m>
       fun indProp =>
-      M.ret (m: 0, existT _ SProp (iBase (sort := SProp) indProp))
+      M.ret (m: 0, existT _ Propₛ (iBase (sort := Propₛ) indProp))
     | Type =m>
       fun indType =>
-      M.ret (m: 0, existT _ (SType) (iBase (sort := SType) indType))
+      M.ret (m: 0, existT _ (Typeₛ) (iBase (sort := Typeₛ) indType))
     | Set =m>
       fun indType =>
-      M.ret (m: 0, existT _ (SType) (iBase (sort := SType) indType))
+      M.ret (m: 0, existT _ (Typeₛ) (iBase (sort := Typeₛ) indType))
     | T =n> fun _=> M.failwith "Impossible ITele"
     end.
 
@@ -390,7 +390,7 @@ Definition new_destruct {A : Type} (n : A) : tactic := \tactic g =>
                         fun ct =>
                            (selem_of (branch_of_CTele rt ct))
                                        ) cts) in
-          goals <- M.map (fun ty=> r <- M.evar ty; M.ret (Metavar SType r)) sg; (*FIX: SType is not right *)
+          goals <- M.map (fun ty=> r <- M.evar ty; M.ret (Metavar Typeₛ r)) sg; (*FIX: Typeₛ is not right *)
           branches <- M.map M.goal_to_dyn goals;
           let tsg := reduce RedHNF (type_of sg) in (*FIX: these reductions should be smarter *)
           let rrf := reduce RedSimpl (RTele_Fun rt) in

--- a/theories/ideas/Pre-typedtactics.v
+++ b/theories/ideas/Pre-typedtactics.v
@@ -158,7 +158,7 @@ Definition compi {A} {B} (g : M A) (h : M B) : M (A * B) :=
 (** Solves goal A provided tactic t *)
 Definition Mby' {A} (t: tactic) : M A :=
   e <- evar A;
-  l <- t (Goal SType e);
+  l <- t (Goal Typeₛ e);
   l' <- T.filter_goals l;
   match l' with mnil => ret e | _ => failwith "couldn't solve" end.
 
@@ -169,14 +169,14 @@ Definition Muse {A} (t: tactic) : M A :=
     of <- unify_univ P A UniMatchNoRed;
     match of with
     | mSome f => e <- M.evar P;
-                 t (Goal SProp e);;
+                 t (Goal Propₛ e);;
                  let e := reduce (RedOneStep [rl: RedBeta]) (f e) in
                  ret e
     | mNone => raise NotAProp
     end
   with | NotAProp =>
     e <- evar A;
-    t (Goal SType e);;
+    t (Goal Typeₛ e);;
     ret e
   end.
 
@@ -195,7 +195,7 @@ Definition dest_pair {T} (x:T) : M (dyn * dyn) :=
 (*     it generates a goal for each unsolved variable in the pair. *)
 Program Definition to_goals : forall {A}, A -> M (mlist (unit *m goal)) :=
   mfix2 to_goals (A: Type) (a: A) : M _ :=
-  mif is_evar a then ret [m: (m: tt, Goal SType a)]
+  mif is_evar a then ret [m: (m: tt, Goal Typeₛ a)]
   else
     mif is_prod A then
       ''(d1, d2) <- dest_pair a;

--- a/theories/ideas/SubgoalsStrict.v
+++ b/theories/ideas/SubgoalsStrict.v
@@ -49,7 +49,7 @@ Import Datatypes.
 (** [max_apply t] applies theorem t to the current goal.
     It generates a subgoal for each non-dependent hypothesis in the theorem. *)
 Definition max_apply {T} (c : T) : tactic := fun g=>
-  match g with @Metavar SType gT eg =>
+  match g with @Metavar Typeₛ gT eg =>
     (mfix1 go (d : dyn) : M (mlist (unit *m goal _)) :=
       (* let (_, el) := d in *)
       (* mif M.unify_cumul el eg UniCoq then M.ret [m:] else *)
@@ -57,7 +57,7 @@ Definition max_apply {T} (c : T) : tactic := fun g=>
         | [? T1 T2 f] @Dyn (T1 -> T2) f =>
           e <- M.evar T1;
           r <- go (Dyn (f e));
-          M.ret ((m: tt, AnyMetavar SType e) :m: r)
+          M.ret ((m: tt, AnyMetavar Typeₛ e) :m: r)
         | [? T1 T2 f] @Dyn (forall x:T1, T2 x) f =>
           e <- M.evar T1;
           r <- go (Dyn (f e));
@@ -67,7 +67,7 @@ Definition max_apply {T} (c : T) : tactic := fun g=>
           dcase d as ty, el in
           M.raise (T.CantApply ty gT)
         end) (Dyn c)
-  | @Metavar SProp _ _ => M.failwith "It's a prop!"
+  | @Metavar Propₛ _ _ => M.failwith "It's a prop!"
   end.
 
 Definition count_nondep_binders (T: Type) : M nat :=

--- a/theories/ideas/Transport.v
+++ b/theories/ideas/Transport.v
@@ -71,9 +71,9 @@ Definition stype_type (sort : Sort) (t : stype_of sort) : Type := (selem_of t) :
 
 Definition gen_match_branch {T1 T2 X} (recursor : T1 -> M T2) (base : T2 -> M X) :=
   fix f (C1_types C2_types : mlist Type) :
-    forall ndc : (NDCfold (@iBase SType T1) C1_types), (lprod C2_types -> M X) -> M (branch_of_NDCTele (rsort := SProp) (it := @iBase SType T1) (fun _ => M X) (existT _ C1_types ndc)) :=
+    forall ndc : (NDCfold (@iBase Typeₛ T1) C1_types), (lprod C2_types -> M X) -> M (branch_of_NDCTele (rsort := Propₛ) (it := @iBase Typeₛ T1) (fun _ => M X) (existT _ C1_types ndc)) :=
     match C1_types as C1_types, C2_types as C2_types return
-          forall ndc : (NDCfold (@iBase SType T1) C1_types), (lprod C2_types -> M X) -> M (branch_of_NDCTele (rsort := SProp) (it := @iBase SType T1) (fun _ => M X) (existT _ C1_types ndc))
+          forall ndc : (NDCfold (@iBase Typeₛ T1) C1_types), (lprod C2_types -> M X) -> M (branch_of_NDCTele (rsort := Propₛ) (it := @iBase Typeₛ T1) (fun _ => M X) (existT _ C1_types ndc))
     with
     | mnil, mnil =>
       fun (F1 : unit -> _) (F2 : unit -> _) =>
@@ -81,9 +81,9 @@ Definition gen_match_branch {T1 T2 X} (recursor : T1 -> M T2) (base : T2 -> M X)
         M.ret c2
     | X1:m:C1_types, X2:m:C2_types =>
       mtmmatch (m: X1, X2) as Xs return
-          forall ndc : (NDCfold (@iBase SType T1) (mfst Xs:m:C1_types)),
+          forall ndc : (NDCfold (@iBase Typeₛ T1) (mfst Xs:m:C1_types)),
             (lprod (msnd Xs:m:C2_types) -> M X) ->
-            M (branch_of_NDCTele (rsort := SProp) (it := @iBase SType T1) (fun _ => M X) (existT _ (mfst Xs:m:C1_types) ndc))
+            M (branch_of_NDCTele (rsort := Propₛ) (it := @iBase Typeₛ T1) (fun _ => M X) (existT _ (mfst Xs:m:C1_types) ndc))
         with
         | [? A : Type] (m: A, A) =u>
           fun (F1 : lprod (mfst (m: A,A):m:_) -> _) (F2 : lprod (msnd (m: A,A):m:_) -> M X)=>
@@ -106,14 +106,14 @@ Definition gen_match_from_to (T1 T2 : Type) X (offset : nat) : M (forall recurso
   i1 <- get_ind_cts T1 O;
   i2 <- get_ind_cts T2 offset;
   mmatch (m: i1, i2) with
-  | [?(n1 : nat) (Cs1 : mlist (NDCTele (@iBase SType T1)))
-      (n2 : nat) (Cs2 : mlist (NDCTele (@iBase SType T2)))]
+  | [?(n1 : nat) (Cs1 : mlist (NDCTele (@iBase Typeₛ T1)))
+      (n2 : nat) (Cs2 : mlist (NDCTele (@iBase Typeₛ T2)))]
       (m:
-        ((n1, existT _ SType (existT _ (@iBase SType T1) Cs1))),
-        ((n2, existT _ SType (existT _ (@iBase SType T2) Cs2)))
+        ((n1, existT _ Typeₛ (existT _ (@iBase Typeₛ T1) Cs1))),
+        ((n2, existT _ Typeₛ (existT _ (@iBase Typeₛ T2) Cs2)))
       ) =>
-    let it1 := @iBase SType T1 in
-    let it2 := @iBase SType T2 in
+    let it1 := @iBase Typeₛ T1 in
+    let it2 := @iBase Typeₛ T2 in
     (if Nat.eqb (mlength Cs1) (mlength Cs2) then M.ret unit else M.failwith "Number of remaining constructors of T2 does not match that of T1");;
     (* let Cs1 := reduce RedVmCompute Cs1 in *)
     (* let Cs2 := reduce RedVmCompute Cs2 in *)

--- a/theories/intf/M.v
+++ b/theories/intf/M.v
@@ -263,7 +263,7 @@ Definition set_trace: bool -> t unit.
  *)
 Definition is_head :
   forall {A : Type} {B : A -> Type} {m} (uni : Unification) (a : A) (C : MTele_ConstT A m)
-         (success : MTele_sort (MTele_ConstMap (si := SType) SProp (T:=A) (fun a => t (B a)) C))
+         (success : MTele_sort (MTele_ConstMap (si := Typeₛ) Propₛ (T:=A) (fun a => t (B a)) C))
          (failure: t (B a)),
     t (B a).
   make. Qed.
@@ -328,13 +328,13 @@ Definition declare_mind
            (constrs :
               mfold_right
                 (fun '(m: _; ind) acc =>
-                   MTele_val (MTele_In SType (fun a' => MTele_Ty (mprojT1 (a'.(acc_constT) ind))))
+                   MTele_val (MTele_In Typeₛ (fun a' => MTele_Ty (mprojT1 (a'.(acc_constT) ind))))
                    -> acc
-                (* MTele_val (MTele_In SType (fun a => MTele_Ty (mprojT1 (a.(acc_const) ind)))) -> acc *)
+                (* MTele_val (MTele_In Typeₛ (fun a => MTele_Ty (mprojT1 (a.(acc_const) ind)))) -> acc *)
                 )%type
                 (
                   (
-                    MTele_val (MTele_In SType
+                    MTele_val (MTele_In Typeₛ
                                         (fun a =>
                                            mfold_right
                                              (fun '(m: _; ind) acc =>
@@ -366,8 +366,8 @@ Set Universe Minimization ToSet.
 
 Definition sorted_evar (s: Sort) : forall T : s, t T :=
   match s with
-  | SProp => fun T:Prop => M.evar T
-  | SType => fun T:Type => M.evar T
+  | Propₛ => fun T:Prop => M.evar T
+  | Typeₛ => fun T:Type => M.evar T
   end.
 
 Definition unify@{a} {A : Type@{a}} (x y : A) (U : Unification) : t@{a} (moption@{a} (meq@{a} x y)) :=
@@ -401,7 +401,7 @@ Definition dbg_term {A} (s: string) (x : A) : t unit :=
 
 Definition decompose_app'
            {A : Type} {B : A -> Type} {m} (uni : Unification) (a : A) (C : MTele_ConstT A m)
-           (success : MTele_sort (MTele_ConstMap (si := SType) SProp (T:=A) (fun a => t (B a)) C)) :
+           (success : MTele_sort (MTele_ConstMap (si := Typeₛ) Propₛ (T:=A) (fun a => t (B a)) C)) :
   t (B a) :=
   is_head uni a C success (raise WrongTerm).
 
@@ -454,12 +454,12 @@ Fixpoint open_pattern@{a p+} {A : Type@{a}} {P : A -> Type@{p}} {y} (E : Excepti
   | @ptele _ _ _ _ C f => e <- evar C; open_pattern E (f e)
   | psort f =>
     mtry'
-      (open_pattern E (f SProp))
+      (open_pattern E (f Propₛ))
       (fun e =>
-         M.unify_cnt UniMatchNoRed e E (open_pattern E (f SType)) (raise e)
+         M.unify_cnt UniMatchNoRed e E (open_pattern E (f Typeₛ)) (raise e)
          (* oeq <- M.unify e E UniMatchNoRed; *)
          (* match oeq with *)
-         (* | mSome _ => open_pattern E (f SType) *)
+         (* | mSome _ => open_pattern E (f Typeₛ) *)
          (* | mNone => raise e *)
          (* end *)
       )
@@ -849,8 +849,8 @@ Definition goal_type (g : goal gs_open) : t Type :=
   match g with
   | @Metavar s A x =>
     match s as s return stype_of s -> t Type with
-      | SProp => fun A => ret (A:Type)
-      | SType => fun A => ret A end A
+      | Propₛ => fun A => ret (A:Type)
+      | Typeₛ => fun A => ret A end A
   end.
 
 (** [goal_prop g] extracts the prop of the goal or raises [CantCoerce] its type
@@ -859,8 +859,8 @@ Definition goal_prop (g : goal gs_open) : t Prop :=
   match g with
   | @Metavar s A _ =>
     match s as s return forall A:stype_of s, t Prop with
-      | SProp => fun A:Prop => ret A
-      | SType => fun A:Type =>
+      | Propₛ => fun A:Prop => ret A
+      | Typeₛ => fun A:Type =>
         gP <- evar Prop;
         mtry
          cumul_or_fail UniMatch gP A;;
@@ -872,8 +872,8 @@ Definition goal_prop (g : goal gs_open) : t Prop :=
 (** Convertion functions from [dyn] to [goal]. *)
 Definition dyn_to_goal (d : dyn) : t (goal gs_open) :=
   mmatch d with
-  | [? (A:Prop) x] @Dyn A x => ret (@Metavar SProp A x)
-  | [? (A:Type) x] @Dyn A x => ret (@Metavar SType A x)
+  | [? (A:Prop) x] @Dyn A x => ret (@Metavar Propₛ A x)
+  | [? (A:Type) x] @Dyn A x => ret (@Metavar Typeₛ A x)
   end.
 
 Definition goal_to_dyn (g : goal gs_open) : t dyn :=

--- a/theories/intf/MTele.v
+++ b/theories/intf/MTele.v
@@ -24,8 +24,8 @@ match n with
 | mBase => T
 | mTele F => ForAll (fun x => MTele_Const T (F x))
 end.
-Definition MTele_ConstP (T : Prop) (n : MTele) : Prop := @MTele_Const SProp T n.
-Definition MTele_ConstT@{i+} (T : Type@{i}) (n : MTele@{i}) : Type@{i} := @MTele_Const SType T n.
+Definition MTele_ConstP (T : Prop) (n : MTele) : Prop := @MTele_Const Propₛ T n.
+Definition MTele_ConstT@{i+} (T : Type@{i}) (n : MTele@{i}) : Type@{i} := @MTele_Const Typeₛ T n.
 
 Fixpoint MTele_const {s : Sort} {T : s} {n : MTele} : @MTele_Const s T n -> stype_of s :=
   match n return MTele_Const T n -> _ with
@@ -33,8 +33,8 @@ Fixpoint MTele_const {s : Sort} {T : s} {n : MTele} : @MTele_Const s T n -> styp
   | mTele F => fun C => ForAll (fun x => MTele_const (App C x))
   end.
 
-Definition MTele_constP {T : Prop} {n} : MTele_ConstP T n -> Prop := @MTele_const SProp T n.
-Definition MTele_constT {T : Type} {n} : MTele_ConstT T n -> Type := @MTele_const SType T n.
+Definition MTele_constP {T : Prop} {n} : MTele_ConstP T n -> Prop := @MTele_const Propₛ T n.
+Definition MTele_constT {T : Type} {n} : MTele_ConstT T n -> Type := @MTele_const Typeₛ T n.
 
 (** MTele_Sort: compute `∀ x .. z, Type` from a given MTele *)
 Definition MTele_Sort@{i j k} (s : Sort) (n : MTele@{i}) : Type@{j} := MTele_ConstT@{j k} (stype_of@{j i} s) n.
@@ -49,8 +49,8 @@ Fixpoint MTele_Sort' (s : Sort) (n : MTele) : Type :=
 (* Lemma MTele_Sort_eq' s n : MTele_Sort' s n -> MTele_Sort s n. *)
 (* Proof. induction n. intros H. exact H. cbn. intros H x. apply X0. apply H. Qed. *)
 
-Definition MTele_Ty := (MTele_Sort SType).
-Definition MTele_Pr := (MTele_Sort SProp).
+Definition MTele_Ty := (MTele_Sort Typeₛ).
+Definition MTele_Pr := (MTele_Sort Propₛ).
 
 (* Definition MTele_sort {s : Sort} {n : MTele} : MTele_Sort s n -> Type := @MTele_constT _ n. *)
 Fixpoint MTele_sort@{i+} {s : Sort} {n : MTele@{i}} :
@@ -72,15 +72,15 @@ Fixpoint MTele_val {s} {n : MTele} : MTele_Sort s n -> s :=
   end.
 
 Definition MTele_valT {n} : MTele_Ty n -> Type :=
-  MTele_val (s := SType) (n:=n).
+  MTele_val (s := Typeₛ) (n:=n).
   (* ltac:( *)
-  (*   let e := constr:(MTele_val (s := SType) (n:=n)) in *)
+  (*   let e := constr:(MTele_val (s := Typeₛ) (n:=n)) in *)
   (*   let e := (eval red in e) in *)
   (*   let e := (eval cbv match beta delta [ForAll stype_of] in e) in *)
   (*   let e := (eval fold MTele_Ty in e) in *)
   (*   exact e). *)
 Definition MTele_valP {n} : MTele_Pr n -> Prop :=
-  MTele_val (s := SProp) (n:=n).
+  MTele_val (s := Propₛ) (n:=n).
 
 (* Coercion MTele_valT : MTele_Ty >-> Sortclass. *)
 
@@ -138,9 +138,9 @@ Set Primitive Projections.
 Record accessor (n : MTele) :=
   Accessor {
       acc_const : forall {s : Sort} {T : s}, MTele_Const T n -> T;
-      acc_constP {P : Prop} : MTele_ConstP P n -> P := @acc_const SProp P;
-      acc_constT {T : Type} : MTele_ConstT T n -> T := @acc_const SType T;
-      acc_sort {s : Sort} : MTele_Sort s n -> s := @acc_const SType _ ;
+      acc_constP {P : Prop} : MTele_ConstP P n -> P := @acc_const Propₛ P;
+      acc_constT {T : Type} : MTele_ConstT T n -> T := @acc_const Typeₛ T;
+      acc_sort {s : Sort} : MTele_Sort s n -> s := @acc_const Typeₛ _ ;
       acc_val : forall {s : Sort} (T : MTele_Sort s n), MTele_val T -> acc_sort T;
     }.
 Arguments acc_const {_} _ {_} {_} _.
@@ -168,11 +168,11 @@ Fixpoint MTele_In (s : Sort) {n : MTele} :
   end.
 
 Notation "'[WithT' now_ty , now_val '=>' T ]" :=
-  (MTele_In SType (fun '(Accessor _ now_ty now_val) => T))
+  (MTele_In Typeₛ (fun '(Accessor _ now_ty now_val) => T))
     (at level 0, format "[WithT  now_ty ,  now_val  =>  T ]").
 
 Notation "'[WithP' now_ty , now_val '=>' T ]" :=
-  (MTele_In SProp (fun '(Accessor _ now_ty now_val) => T))
+  (MTele_In Propₛ (fun '(Accessor _ now_ty now_val) => T))
     (at level 0, format "[WithP  now_ty ,  now_val  =>  T ]").
 
 (** MTele_in: gain access to potentially multiple telescoped types and values at the same time to compute a new telescoped _value_ of type `MTele_In ..`. *)
@@ -201,26 +201,26 @@ Fixpoint MTele_in (s : Sort) {n : MTele} :
   end.
 
 Notation "'[withT' now_ty , now_val '=>' t ]" :=
-  (MTele_in (SType) (fun '(Accessor _ now_ty now_val) => t))
+  (MTele_in (Typeₛ) (fun '(Accessor _ now_ty now_val) => t))
     (at level 0, format "[withT  now_ty ,  now_val  =>  t ]").
 
 Notation "'[withP' now_ty , now_val '=>' t ]" :=
-  (MTele_in (SProp) (fun '(Accessor _ now_ty now_val) => t))
+  (MTele_in (Propₛ) (fun '(Accessor _ now_ty now_val) => t))
     (at level 0, format "[withP  now_ty ,  now_val  =>  t ]").
 
 (** MTele_Map: compute type `∀ x .. z, B x .. z` from type
     `∀ x .. z, A x .. z` *)
 Fixpoint MTele_Map (s so : Sort) {n : MTele} :
-  MTele_sort (MTele_In (SType) (n := n) (fun _ => stype_of s -> stype_of so)) -> MTele_Sort s n -> MTele_Sort so n
+  MTele_sort (MTele_In (Typeₛ) (n := n) (fun _ => stype_of s -> stype_of so)) -> MTele_Sort s n -> MTele_Sort so n
   :=
   match n return
-        MTele_sort (MTele_In (SType) (n := n) (fun _ => stype_of s -> stype_of so)) -> MTele_Sort s n -> MTele_Sort so n
+        MTele_sort (MTele_In (Typeₛ) (n := n) (fun _ => stype_of s -> stype_of so)) -> MTele_Sort s n -> MTele_Sort so n
   with
   | mBase => fun f A => f A
   | mTele F => fun f A t => @MTele_Map s so (F t) (f t) (A t)
   end.
 
-Eval cbn in MTele_In (SType).
+Eval cbn in MTele_In (Typeₛ).
 
 (** MTele_C: MTele_map with a constant function *)
 Fixpoint MTele_C (s so : Sort) {n : MTele} :
@@ -299,7 +299,7 @@ Fixpoint apply_const {s : Sort} {m : MTele} {T : s} :
 
 Definition apply_sort {s : Sort} {m : MTele} :
   MTele_Sort s m -> ArgsOf m -> stype_of s :=
-  @apply_const SType m (stype_of s).
+  @apply_const Typeₛ m (stype_of s).
 
 Fixpoint apply_val {s : Sort} {m : MTele} :
   forall {T : MTele_Sort s m} (v : MTele_val T) (a : ArgsOf m), selem_of (apply_sort T a) :=
@@ -314,7 +314,7 @@ Fixpoint apply_val {s : Sort} {m : MTele} :
 
 Definition MTele_ty (M : Type -> Prop) {n : MTele} :
   forall A : MTele_Ty n, Prop :=
-  fun A => MTele_val (MTele_C SType SProp M A).
+  fun A => MTele_val (MTele_C Typeₛ Propₛ M A).
 
 Notation MT_Acc R T := (forall (M' : Type -> Prop), MTele_ty M' T -> M' R).
 

--- a/theories/intf/Sorts.v
+++ b/theories/intf/Sorts.v
@@ -5,13 +5,22 @@ Unset Universe Minimization ToSet.
 Set Universe Polymorphism.
 Unset Universe Minimization ToSet.
 
+
+Inductive Block_DONT_COMMIT := SType | SProp.
+
+
+Reserved Notation "Typeₛ".
+Reserved Notation "Propₛ".
 Module S.
 
-Monomorphic Inductive Sort : Type := SProp | SType.
+Monomorphic Inductive Sort : Type := Prop_sort | Type_sort.
+
+Notation "Typeₛ" := Type_sort.
+Notation "Propₛ" := Prop_sort.
 
 (** Creates a fresh type according to [s] *)
 Definition stype_of (s : Sort) : Type :=
-  match s with SType => Type | SProp => Prop end.
+  match s with Typeₛ => Type | Propₛ => Prop end.
 Arguments stype_of !_ : simpl nomatch.
 
 (** When working with a sort [s], we cannot simply say "we have an
@@ -19,18 +28,18 @@ Arguments stype_of !_ : simpl nomatch.
     [T] is a [stype_of s]. *)
 Definition selem_of@{i j+} {s : Sort} : stype_of@{i j} s -> Type@{j} :=
   match s return stype_of s -> Type@{j} with
-  | SType => fun x => x
-  | SProp => fun x => x
+  | Typeₛ => fun x => x
+  | Propₛ => fun x => x
   end.
 Arguments selem_of {!_} _ : simpl nomatch.
 
 Fail Local Example CannotMakeAnElementOfaSort s (P : stype_of s) (x : P) := x.
 Local Example WeCanWithElemOf s (P : stype_of s) (x : selem_of P) := x.
 
-Definition selem_lift {s : Sort} : @selem_of SType (stype_of s) -> Type :=
-  match s as s' return @selem_of SType (stype_of s') -> Type with
-  | SType => fun x => x
-  | SProp => fun y => y
+Definition selem_lift {s : Sort} : @selem_of Typeₛ (stype_of s) -> Type :=
+  match s as s' return @selem_of Typeₛ (stype_of s') -> Type with
+  | Typeₛ => fun x => x
+  | Propₛ => fun y => y
   end.
 
 
@@ -41,8 +50,8 @@ Definition ForAll
     sort as sort'
     return ((A -> stype_of sort') -> stype_of sort')
   with
-  | SProp => fun F => forall a : A, F a
-  | SType => fun F => forall a : A, F a
+  | Propₛ => fun F => forall a : A, F a
+  | Typeₛ => fun F => forall a : A, F a
   end.
 
 Definition Impl {sort : Sort} A (B : stype_of sort) : stype_of sort :=
@@ -53,26 +62,26 @@ Definition Fun {sort} {A : Type} :
   match sort as sort' return
         forall {F : A -> stype_of sort'}, (forall a, selem_of (F a)) -> selem_of (ForAll F)
   with
-  | SProp => fun _ f => f
-  | SType => fun _ f => f
+  | Propₛ => fun _ f => f
+  | Typeₛ => fun _ f => f
   end.
 
 Definition App {sort} {A : Type} : forall {F : A -> _},  selem_of (ForAll (sort := sort) F) -> forall a, selem_of (F a) :=
   match sort as sort' return forall F, selem_of (ForAll (sort := sort') F) -> forall a, selem_of (F a) with
-  | SProp => fun F f a => f a
-  | SType => fun F f a => f a
+  | Propₛ => fun F f a => f a
+  | Typeₛ => fun F f a => f a
   end.
 
 Definition Impl_lift {sort} {A : Type} : forall {B : stype_of sort}, (A -> selem_of B) -> selem_of (Impl A B) :=
   match sort with
-  | SProp => fun B f => f
-  | SType => fun B f => f
+  | Propₛ => fun B f => f
+  | Typeₛ => fun B f => f
   end.
 
 Definition lift_Impl {sort} {A : Type} : forall {B : stype_of sort}, selem_of (Impl A B) -> (A -> selem_of B) :=
   match sort with
-  | SProp => fun B f => f
-  | SType => fun B f => f
+  | Propₛ => fun B f => f
+  | Typeₛ => fun B f => f
   end.
 
 
@@ -81,8 +90,23 @@ End S.
 Import S.
 
 Delimit Scope Sort_scope with sort.
-Notation "'[sort' '∀' x .. y , T ]" := (ForAll (fun x => .. (fun y => T) ..)) (x binder, y binder) : Sort_scope.
-Notation "'[sort' 'λ' x .. y , T ]" := (Fun (fun x => .. (fun y => T) ..)) (x binder, y binder, T at next level) : Sort_scope.
+Notation "Typeₛ" := Type_sort.
+Notation "Propₛ" := Prop_sort.
+Notation "forallₛ  x .. y ,  T" :=
+  (ForAll (fun x => .. (fun y => T) ..))
+    (at level 200, x binder, y binder) : Sort_scope.
+Notation "∀ₛ  x .. y ,  T" :=
+  (ForAll (fun x => .. (fun y => T) ..))
+ (at level 200, x binder, y binder).
+Notation "S ->ₛ T" :=
+  (∀ₛ _ : S, T)%sort
+    (at level 200) : Sort_scope.
+Notation "funₛ  x .. y =>  t" :=
+  (Fun (fun x => .. (fun y => t) ..))
+    (at level 200, x binder, y binder) : Sort_scope.
+Notation "λₛ  x .. y ,  t" :=
+  (Fun (fun x => .. (fun y => t) ..))
+    (at level 200, x binder, y binder) : Sort_scope.
 
 Coercion stype_of : Sort >-> Sortclass.
 Coercion selem_of : stype_of >-> Sortclass.

--- a/theories/meta/MFix.v
+++ b/theories/meta/MFix.v
@@ -6,7 +6,7 @@ Set Universe Polymorphism.
 Unset Universe Minimization ToSet.
 
 
-Local Definition MFA {n} (T : MTele_Ty n) := (MTele_val (MTele_C SType SProp M T)).
+Local Definition MFA {n} (T : MTele_Ty n) := (MTele_val (MTele_C Typeₛ Propₛ M T)).
 
 (* Less specific version of MTele_of in MTeleMatch.v *)
 Definition MTele_of' :=

--- a/theories/meta/MFixDef.v
+++ b/theories/meta/MFixDef.v
@@ -5,7 +5,7 @@ Import M.notations.
 Set Universe Polymorphism.
 Unset Universe Minimization ToSet.
 
-Local Notation MFA T := (MTele_val (MTele_C SType SProp M T)).
+Local Notation MFA T := (MTele_val (MTele_C Typeₛ Propₛ M T)).
 
 Fixpoint uncurry {m : MTele} :
   forall {T : MTele_Ty m},

--- a/theories/meta/MTeleMatchDef.v
+++ b/theories/meta/MTeleMatchDef.v
@@ -18,7 +18,7 @@ Arguments mtptele {A m C} _.
 Arguments mtpsort {A m} _.
 
 
-Local Notation MFA T := (MTele_val (MTele_C SType SProp M T)).
+Local Notation MFA T := (MTele_val (MTele_C Typeₛ Propₛ M T)).
 
 Polymorphic Definition mtmmatch' A m (T : forall x, MTele_Ty (m x)) (y : A)
            (ps : mlist (mtpattern A (fun x => MFA (T x)))) : selem_of (MFA (T y)) :=
@@ -65,11 +65,11 @@ Polymorphic Definition mtmmatch' A m (T : forall x, MTele_Ty (m x)) (y : A)
                           go (f c)
                         | mtpsort f =>
                           M.mtry'
-                            (go (f SProp))
+                            (go (f Propₛ))
                             (fun e =>
                               oeq <- M.unify e DoesNotMatch UniMatchNoRed;
                               match oeq with
-                              | mSome _ => go (f SType)
+                              | mSome _ => go (f Typeₛ)
                               | mNone => M.raise e
                               end
                             )

--- a/theories/tactics/CompoundTactics.v
+++ b/theories/tactics/CompoundTactics.v
@@ -19,7 +19,7 @@ Definition simple_rewrite A {x y : A} (p : x = y) : tactic := fun g=>
   | mSome r =>
     newG <- evar (r y);
     T.exact (eq_rect y _ newG x (eq_sym p)) g;;
-    ret [m: (m: tt, AnyMetavar SType newG)]
+    ret [m: (m: tt, AnyMetavar Typeₛ newG)]
   | mNone => M.raise SimpleRewriteNoOccurrence
   end.
 

--- a/theories/tactics/Ttactics.v
+++ b/theories/tactics/Ttactics.v
@@ -31,12 +31,12 @@ Definition to_goal (A : Type) : M (A *m goal gs_open) :=
     match of with
     | mSome f => a <- M.evar P;
                  let a' := reduce (RedOneStep [rl: RedBeta]) (f a) in
-                 ret (m: a', Metavar SProp a)
+                 ret (m: a', Metavar Propₛ a)
     | mNone => raise NotAProp (* we backtrack to erase P *)
     end
   with [#] NotAProp | =n>
     a <- evar A;
-    M.ret (m: a, Metavar SType a)
+    M.ret (m: a, Metavar Typeₛ a)
   end.
 
 (** [demote] is a [ttac] that proves anything by simply postponing it as a
@@ -167,7 +167,7 @@ Definition tpass {A} := lift (M.evar A).
 Definition texists {A} {Q:A->Prop} : ttac (exists (x:A), Q x) :=
   e <- M.evar A;
   pf <- M.evar (Q e);
-  M.ret (m: ex_intro _ e pf, [m: AnyMetavar SProp pf]).
+  M.ret (m: ex_intro _ e pf, [m: AnyMetavar Propₛ pf]).
 
 Definition tassumption {A:Type} : ttac A :=
   lift (M.select _).
@@ -211,11 +211,11 @@ Definition rewrite {X : Type} (C : X -> Type) {a b : X} (H : a = b) :
  *)
 Definition with_goal_prop (F : forall (P : Prop), ttac P) : tactic := fun g =>
   match g with
-  | @Metavar S.SProp G g =>
+  | @Metavar Propₛ G g =>
     ''(m: x, gs) <- F G;
     M.cumul_or_fail UniCoq x g;;
     M.map (fun g => M.ret (m:tt,g)) gs
-  | @Metavar S.SType G g =>
+  | @Metavar Typeₛ G g =>
     gP <- evar Prop;
     mtry
       cumul_or_fail UniMatch gP G;;
@@ -230,11 +230,11 @@ Definition with_goal_prop (F : forall (P : Prop), ttac P) : tactic := fun g =>
  *)
 Definition with_goal_type (F : forall (T : Type), ttac T) : tactic := fun g =>
   match g with
-  | @Metavar S.SProp G g =>
+  | @Metavar Propₛ G g =>
     ''(m: x, gs) <- F G;
     M.cumul_or_fail UniCoq x g;;
     M.map (fun g => M.ret (m:tt,g)) gs
-  | @Metavar S.SType G g =>
+  | @Metavar Typeₛ G g =>
     gP <- evar Prop;
     mtry
       cumul_or_fail UniMatch gP G;;


### PR DESCRIPTION
This commit gives longer names to the constructors of `Sort`: `Type_sort` and `Prop_sort`. To avoid having to type those names, the commit also introduces notation `Typeₛ` and `Propₛ`. On top of that, I also added some more speculative notations: `funₛ, λₛ, forallₛ, ∀ₛ, ->ₛ`. These are not used yet explicitly yet but I think they improve readability in functions that use `Fun` and `ForAll`.

Note that this commit disables the `unrecognized_unicode` warning. Hopefully this will not be necessary in the future once https://github.com/coq/coq/issues/9500 is resolved.