### PR TITLE
Throw `DoesNotMatchGoal` instead of `DoesNotMatch`.

### DIFF
--- a/theories/tactics/Ttactics.v
+++ b/theories/tactics/Ttactics.v
@@ -309,7 +309,7 @@ Fixpoint match_goal_pattern'
                                    (* avoid [selem_of] coercions *)
                                    (with_upcast t)
                                    (raise DoesNotMatchGoal)
-      ) (DoesNotMatch) g
+      ) (DoesNotMatchGoal) g
   | @gtele C f, @ahyp A a d :m: l2' =>
     oeqCA <- M.unify C A u;
     match oeqCA with


### PR DESCRIPTION
Fixes a simple oversight in Ttactics.v.