### PR TITLE
Make M.t a CoInductive

### DIFF
--- a/tests/declare.v
+++ b/tests/declare.v
@@ -3,9 +3,8 @@ Import M.notations.
 Definition test := c <- M.declare dok_Definition "bla" false 1; M.print_term c.
 Goal unit.
   MProof.
-  (* TODO: inlining test here doesn't work because of universes. *)
-  Fail c <- M.declare dok_Definition "bla" false 1; M.print_term c.
-  test.
+  (* TODO: inlining test here used to *not* work because of universes. *)
+  c <- M.declare dok_Definition "bla" false 1; M.print_term c.
 Qed.
 
 Goal unit.
@@ -82,18 +81,18 @@ Print NAT4. (* definitions before the failing one are declared. *)
 
 (* we should check that the terms are closed w.r.t. section variables *)
 (* JANNO: for now we just raise an catchable exception. *)
-Compute fun x y =>
+Fail Compute fun x y =>
           ltac:(mrun (
                     mtry
                       M.declare dok_Definition "lenS" true (Le.le_n_S x y);; M.ret tt
-                      with | UnboundVar => M.ret tt end
+                      with | UnboundVar => M.failwith "This must fail" | _ => M.ret tt end
                )).
 
-(* This fails because of weird universe issues. *)
-Fail Compute ltac:(mrun (c <- M.declare dok_Definition "blu" true (Le.le_n_S); M.print_term c)).
+(* This used to fail because of weird universe issues. *)
+Compute ltac:(mrun (c <- M.declare dok_Definition "blu" true (Le.le_n_S); M.print_term c)).
 Definition decl_blu := (c <- M.declare dok_Definition "blu" true (Le.le_n_S); M.print_term c).
-(* TODO: again, inlining does not work here. *)
-Compute ltac:(mrun decl_blu).
+(* This now fails because the previous failure no longer exists and [blu] is declared. *)
+Fail Compute ltac:(mrun decl_blu).
 
 Print blu.
 

--- a/tests/declare.v
+++ b/tests/declare.v
@@ -4,6 +4,7 @@ Definition test := c <- M.declare dok_Definition "bla" false 1; M.print_term c.
 Goal unit.
   MProof.
   (* TODO: inlining test here doesn't work because of universes. *)
+  Fail c <- M.declare dok_Definition "bla" false 1; M.print_term c.
   test.
 Qed.
 
@@ -88,8 +89,8 @@ Compute fun x y =>
                       with | UnboundVar => M.ret tt end
                )).
 
-(* This basically fails because of weird universe issues. *)
-Compute M.eval (c <- M.declare dok_Definition "blu" true (Le.le_n_S); M.print_term c).
+(* This fails because of weird universe issues. *)
+Fail Compute ltac:(mrun (c <- M.declare dok_Definition "blu" true (Le.le_n_S); M.print_term c)).
 Definition decl_blu := (c <- M.declare dok_Definition "blu" true (Le.le_n_S); M.print_term c).
 (* TODO: again, inlining does not work here. *)
 Compute ltac:(mrun decl_blu).

--- a/theories/intf/M.v
+++ b/theories/intf/M.v
@@ -15,7 +15,8 @@ Unset Printing Notations.
 
 Module M.
 
-Variant t : Type -> Prop := mkt : forall{a}, t a.
+CoInductive t (a : Type) : Prop := mkt : t a.
+Arguments mkt {_}.
 
 Local Ltac make := refine (mkt) || (intro; make).
 
@@ -370,8 +371,9 @@ Definition sorted_evar (s: Sort) : forall T : s, t T :=
   | Typeₛ => fun T:Type => M.evar T
   end.
 
+Set Printing Universes.
 Definition unify@{a} {A : Type@{a}} (x y : A) (U : Unification) : t@{a} (moption@{a} (meq@{a} x y)) :=
-  unify_cnt (B:=fun x => moption@{a} (meq x y)) U x y
+  unify_cnt@{a a} (A:=A) (B:=fun x => moption@{a} (meq x y)) U x y
             (ret@{a} (mSome@{a} (@meq_refl _ y)))
             (ret@{a} mNone@{a}).
 


### PR DESCRIPTION
This commit makes `M.t` into a CoInductive instead of a Variant. This fixes two universe issues in tests/declare.v.