### PR TITLE
Allow `'` (single-quote patterns) in bind notation.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,10 @@
+Changes from 1.1 to 1.2
+=======================
+
+Notation:
+
+- Combining the `.. <- ..; ..` (`M.bind`) notation and Coq's support for patterns (as in
+  `let '(existT _ x P) = .. in ..`) now works without adding an additional
+  apostrophe `'`. For example, `'(existT _ x P) <- some_function(); ..` is now
+  legal. Previously, one had to write `''(existT _ x P) <- some_function(); ..`.
+  This old syntax is no longer available.

--- a/theories/DecomposeApp.v
+++ b/theories/DecomposeApp.v
@@ -45,7 +45,7 @@ Definition MTele_of (A : Type) : forall T, T -> M (msigT (MTele_Const (s:=Type�
                    M.nu (FreshFrom T) mNone (fun x =>
                                    let Fx := reduce (RedOneStep [rl:RedBeta]) (F x) in
                                    let tx := (* rone_step *) (t x) in
-                                   ''(mexistT _ n T) <- f Fx tx;
+                                   '(mexistT _ n T) <- f Fx tx;
                                    n' <- M.abs_fun (P:=fun _ => MTele) x n;
                                    T' <- M.coerce T;
                                    T' <- M.abs_fun (P:=fun x => MTele_Const (s:=Typeₛ) A (n' x)) x T';
@@ -61,7 +61,7 @@ Definition decompose_app {m : MTele} {A : Type} {B : A -> Type} {C : MTele_Const
   :
   M (Unification -> MTele_sort (MTele_ConstMap (si:=Typeₛ) Propₛ (fun a : A => M (B a)) C) -> M (B a)) :=
   (
-    ''(mexistT _ m' T') <- MTele_of A T t;
+    '(mexistT _ m' T') <- MTele_of A T t;
     M.unify m m' UniCoq;;
     M.cumul UniCoq C t;;
     let x := fun u => @M.decompose_app' A B m u a C in
@@ -93,7 +93,7 @@ Defined.
 Definition decompose_app_tactic {m : MTele} {A : Type} {B : A -> Type} {C : MTele_ConstT A m} {T: Type} (a : A) (t : T) :
   M (Unification -> MTele_sort (MTele_ConstMap (si:=Typeₛ) Propₛ (fun a : A => gtactic (B a)) C) -> gtactic (B a)) :=
   (
-    ''(mexistT _ m' T') <- MTele_of A T t;
+    '(mexistT _ m' T') <- MTele_of A T t;
     M.unify m m' UniCoq;;
     M.cumul UniCoq C t;;
     let x := fun uni f (g : goal gs_open) => @M.decompose_app' A (fun a => mlist (mprod (B a) (goal gs_any))) m uni a C (f g) in

--- a/theories/ideas/Abstract.v
+++ b/theories/ideas/Abstract.v
@@ -65,7 +65,7 @@ Definition construct_case A (x: A) (loop: forall r: dynr, M (moption (result x (
   let 'mkCase _ val retrn branches := C in
   nu (FreshFromStr "v") mNone (fun v=>
     new_val_opt <- loop (Dynr val);
-    ''(m: some_branch_depends, new_branches) <-
+    '(m: some_branch_depends, new_branches) <-
      M.fold_right (
        fun branch '(m: some_branch_depends, new_branches) =>
          b <- to_dynr branch;

--- a/theories/ideas/Pre-typedtactics.v
+++ b/theories/ideas/Pre-typedtactics.v
@@ -45,7 +45,7 @@ Local Fixpoint TTele_bind' {X : Prop} (x : X) {t} : (TTele_ty (fun T => msigT (f
   match t with
   | ttbase B => fun '(mexistT _ l f) => mexistT _ (X :m: l) (
                   H <- M.evar X;
-                  ''(goals, R) <- f H;
+                  '(goals, R) <- f H;
                   M.ret ((H,goals), R))
   | tttele F => fun f t =>
                   TTele_bind' x (f t)
@@ -65,7 +65,7 @@ Definition lift_lemma : forall (A : Prop), A ->
               (mtptele (fun B:Prop => mtptele (fun (C:Prop) => (mtpbase ( m:=fun A:Prop => A -> M _)) _ (
               fun (f : B -> C) =>
                 M.nu (FreshFrom A) mNone (fun b : B =>
-                               ''(mexistT _ t X) <- rec C (f b);
+                               '(mexistT _ t X) <- rec C (f b);
                                match t as t return tty t -> M (_) with
                                | tttele _ =>
                                  fun _ =>
@@ -84,7 +84,7 @@ Definition lift_lemma : forall (A : Prop), A ->
              (mtptele (fun B:Type => mtptele (fun (C:B -> Prop) => (mtpbase ( m:=fun A:Prop => A -> M _)) _ (
               fun (f : forall b:B, C b) =>
                 M.nu (FreshFrom A) mNone (fun b : B =>
-                               ''(mexistT _ t X) <- rec _ (f b);
+                               '(mexistT _ t X) <- rec _ (f b);
                                t' <- M.abs_fun b t;
                                X <- M.coerce X;
                                X' <- M.abs_fun (P:=fun b => tty (t' b)) b X;
@@ -116,7 +116,7 @@ match t with
 end.
 
 Definition do_def n {A:Prop} (a:A) :=
-  ''(mexistT _ t f) <- lift_lemma A (a);
+  '(mexistT _ t f) <- lift_lemma A (a);
   (* let f := reduce (RedStrong [rl: RedBeta; RedZeta; RedFix; RedMatch; RedDeltaOnly [rl: Dyn (@M.type_of); Dyn (@TTele_ty)] ]) (f) in *)
   let x := reduce (RedStrong [rl: RedFix; RedMatch; RedBeta; RedDeltaOnly [rl: Dyn (@TTele_app)]]) (TTele_app (fun T PT => let '(mexistT _ l _) := PT in M (l -*> T))
                                                 (fun T PT => let '(mexistT _ l X) := PT in
@@ -145,7 +145,7 @@ Notation "T1 '|m-' G" := (myprod T1 G)
 
 (** composes on the left of the arrow *)
 Definition compl {A} {B} (f: M (A |m- B)) (g : M A) : M B :=
-  ''(a, b) <- f;
+  '(a, b) <- f;
   a' <- g;
   mif unify a a' UniCoq then
     ret b
@@ -198,7 +198,7 @@ Program Definition to_goals : forall {A}, A -> M (mlist (unit *m goal)) :=
   mif is_evar a then ret [m: (m: tt, Goal Typeₛ a)]
   else
     mif is_prod A then
-      ''(d1, d2) <- dest_pair a;
+      '(d1, d2) <- dest_pair a;
       dcase d1 as x in
       dcase d2 as y in
       t1s <- to_goals _ x;
@@ -211,7 +211,7 @@ Program Definition to_goals : forall {A}, A -> M (mlist (unit *m goal)) :=
 Definition to_tactic {A B} (f: M (A |m- B)) : tactic := fun g=>
   gT <- goal_type g;
   mif unify gT B UniCoq then
-    ''(a, b) <- f;
+    '(a, b) <- f;
     al <- to_goals a;
     ls <- T.filter_goals al;
     T.exact b g;;

--- a/theories/ideas/non_refl_refl.v
+++ b/theories/ideas/non_refl_refl.v
@@ -229,15 +229,15 @@ Definition abs_prod' {A} (F: A->Type) : M {T:Type& T =m= forall x, F x}.
 (** Just for the record, this is how you get the original abs_prod *)
 Definition abs_prod {A} (x:A) (t: Type) : M Type :=
   f <- M.abs_fun x t;
-  ''(existT _ T _) <- abs_prod' f;
+  '(existT _ T _) <- abs_prod' f;
   M.ret T.
 
 (** A version of [abs_prod] returning proofs: given [x] and [t], it returns a
 term [T] and a function [F] such that [T = forall y, F y], and [F x = t]. *)
 Definition abs_prod_pf {A} (x:A) (t: Type) : M {T & {F & F x =m= t /\ T =m= forall x, F x}}.
   refine (
-  ''(existT _ f pf) <- abs_fun'' x t;
-  ''(existT _ T pfT) <- abs_prod' f;
+  '(existT _ f pf) <- abs_fun'' x t;
+  '(existT _ T pfT) <- abs_prod' f;
   M.ret _).
   exists T.
   exists f.

--- a/theories/meta/Exhaustive.v
+++ b/theories/meta/Exhaustive.v
@@ -33,7 +33,7 @@ Definition check_exhaustiveness {A B y}
            (ps_in : mlist (branch M A B y))
            (ops : moption (mlist (branch M A B y))) :
   M (mlist (branch M A B y)) :=
-  ''(mpair _ constrs) <- M.constrs A;
+  '(mpair _ constrs) <- M.constrs A;
   (
     mfix2 f (ps : _) (constrs : _) : M _ :=
       match ps, constrs with

--- a/theories/meta/MFix.v
+++ b/theories/meta/MFix.v
@@ -18,7 +18,7 @@ Definition MTele_of' :=
                               )
      | [?(X : Type) (F : forall x:X, Prop)] (forall x:X, F x) =c> [H]
        M.nu (FreshFrom F) mNone (fun x =>
-                       ''(existT _ m (existT _ mT E)) <- f (F x);
+                       '(existT _ m (existT _ mT E)) <- f (F x);
                        m' <- M.abs_fun x m;
                        mT' <- (M.coerce mT >>=
                                M.abs_fun (P:=fun x => MTele_Ty (m' x)) x);
@@ -42,7 +42,7 @@ Definition MTele_of : Prop -> M (sigT MTele_Ty) :=
      | [?X : Type] M X =u> M.ret (existT _ mBase X)
      | [?(X : Type) (F : forall x:X, Prop)] (forall x:X, F x) =c>
        M.nu (FreshFrom F) mNone (fun x =>
-                       ''(existT _ n T) <- f (F x);
+                       '(existT _ n T) <- f (F x);
                        n' <- M.abs_fun (P:=fun _ => MTele) x n;
                        T' <- M.abs_fun x T;
                        T' <- M.coerce T';
@@ -78,7 +78,7 @@ Definition mfix_eq {m : MTele} {T: MTele_Ty m} {A : Prop} : forall {Eq : MFA T =
 
 Definition mfix_lift {m : MTele} {A : Prop} {F : (A -> A) -> A}:
   lift (
-     ''(existT _ m' (existT _ mT E)) <-mtry  MTele_of' A
+     '(existT _ m' (existT _ mT E)) <-mtry  MTele_of' A
         with
     | [?E] E =>
       M.print_term E;;

--- a/theories/meta/MTeleMatch.v
+++ b/theories/meta/MTeleMatch.v
@@ -14,7 +14,7 @@ Definition MTele_of {A:Type} (T : A -> Prop) : M (A -> msigT MTele_Ty) :=
     | [?(X : Type) (F : forall x:X, Prop)] (forall x:X, F x) =u>
       M.nu (FreshFrom T) mNone (fun x =>
                       let T' := reduce (RedOneStep [rl:RedBeta]) (F x) in
-                      ''(mexistT _ n T) <- f T';
+                      '(mexistT _ n T) <- f T';
                       n' <- M.abs_fun x n;
                       T' <- (M.coerce (B:=MTele_Ty (n' x)) T >>= M.abs_fun x);
                       M.ret (mexistT _ (mTele n') T')

--- a/theories/tactics/Tactics.v
+++ b/theories/tactics/Tactics.v
@@ -45,7 +45,7 @@ Definition eexact {A} (x:A) : tactic := fun g =>
   | @Metavar _ _ g =>
     M.cumul_or_fail UniCoq x g;;
     l <- M.collect_evars g;
-    M.map (fun d => ''(@Metavar _ _ g) <- M.dyn_to_goal d; M.ret (m: tt, AnyMetavar _ g)) l
+    M.map (fun d => '(@Metavar _ _ g) <- M.dyn_to_goal d; M.ret (m: tt, AnyMetavar _ g)) l
   end.
 
 (** [intro_base n t] introduces variable or definition named [n]
@@ -164,14 +164,14 @@ Definition generalize {A} (x : A) : tactic := fun g =>
 Definition cclear {A B} (x:A) (cont : gtactic B) : gtactic B := fun g=>
   match g with
   | @Metavar Propₛ gT _ =>
-    ''(e,l) <- M.remove x (
+    '(e,l) <- M.remove x (
       e <- M.evar gT;
       l <- cont (Metavar Propₛ e);
       M.ret (e, l));
     exact e g;;
     rem_hyp x l
   | @Metavar Typeₛ gT _ =>
-    ''(e,l) <- M.remove x (
+    '(e,l) <- M.remove x (
       e <- M.evar gT;
       l <- cont (Metavar Typeₛ e);
       M.ret (e, l));
@@ -204,7 +204,7 @@ Definition destruct {A : Type} (n : A) : tactic := fun g =>
              |} in
     case <- M.makecase c;
     dcase case as e in exact e g;;
-    M.map (fun d => ''(@Metavar _ _ g) <- M.dyn_to_goal d; M.ret (m: tt, AnyMetavar _ g)) l
+    M.map (fun d => '(@Metavar _ _ g) <- M.dyn_to_goal d; M.ret (m: tt, AnyMetavar _ g)) l
   | _ => I                      (* This makes no sense. It should not be necessary. *)
   end.
 
@@ -289,7 +289,7 @@ Definition change_hyp {P Q} (H : P) (newH: Q) : tactic := fun g=>
   match g with
   | @Metavar sort gT _ =>
      name <- M.get_binder_name H;
-     ''(m: gabs, abs) <- M.remove H (M.nu (TheName name) mNone (fun nH: Q=>
+     '(m: gabs, abs) <- M.remove H (M.nu (TheName name) mNone (fun nH: Q=>
        r <- M.evar gT;
        abs <- M.abs_fun nH r;
        gabs <- M.abs_fun nH (AnyMetavar sort r);
@@ -460,7 +460,7 @@ Definition n_etas (n : nat) {A} (f : A) : M A :=
     [n] products. *)
 Definition fix_tac (f : name) (n : N) : tactic := fun g =>
   gT <- M.goal_type g;
-  ''(f, new_goal) <- M.nu f mNone (fun f : gT =>
+  '(f, new_goal) <- M.nu f mNone (fun f : gT =>
     (* We introduce the recursive definition f and create the new
        goal having it. *)
     new_goal <- M.evar gT;
@@ -635,7 +635,7 @@ Definition apply_one_of (l : mlist dyn) : tactic :=
 
 (** Tries to apply each constructor of the goal type *)
 Definition constructor : tactic :=
-  ''(m: _, l) <- M.constrs =<< goal_type;
+  '(m: _, l) <- M.constrs =<< goal_type;
   apply_one_of l.
 
 Definition apply_in {P Q} (c : P -> Q) (H : P) : tactic :=

--- a/theories/tactics/TacticsBase.v
+++ b/theories/tactics/TacticsBase.v
@@ -116,7 +116,7 @@ Definition goal_prop : gtactic Prop := with_goal M.goal_prop.
 Definition ltac (t : string) (args : mlist dyn) : tactic := fun g =>
   match g with
   | @Metavar s ty el =>
-    ''(m: v, l) <- @M.call_ltac s ty t args;
+    '(m: v, l) <- @M.call_ltac s ty t args;
     M.unify_or_fail UniCoq v el;;
     let l' := dreduce (@mmap) (mmap (mpair tt) l) in
     M.ret l'
@@ -148,7 +148,7 @@ Definition Backtrack {A} {B} (x:A) (C : A -> B) : Exception.
 Definition abstract_from_term_dep {A} {B} (x:A) (y:B) (D : B -> Type)
            (ok : forall C : A -> B, M (D (C x))) (fail : M (D y)) : M (D y) :=
   mtry
-    ''(m: _, gs) <- M.call_ltac Propₛ (A:=wrapper y) "Mssrpattern" [m:Dyn x];
+    '(m: _, gs) <- M.call_ltac Propₛ (A:=wrapper y) "Mssrpattern" [m:Dyn x];
     mmatch gs with
     | [? y (f:A->B) t] [m: @AnyMetavar Propₛ (let z := y in wrapper (f z)) t] =u>
       M.raise (@Backtrack A B y f) (* nasty HACK: we backtract so as not to get evars
@@ -383,9 +383,12 @@ Module notations.
   Notation "r '<-' t1 ';' t2" := (bind t1 (fun r => t2%tactic))
     (at level 20, t1 at level 100, t2 at level 200,
      format "'[' r  '<-'  '[' t1 ;  ']' ']' '/' t2 ") : tactic_scope.
-  Notation "' r1 .. rn '<-' t1 ';' t2" := (bind t1 (fun r1 => .. (fun rn => t2%tactic) ..))
-    (at level 20, r1 binder, rn binder, t1 at level 100, t2 at level 200,
-     format "'[' ''' r1 .. rn  '<-'  '[' t1 ;  ']' ']' '/' t2 ") : tactic_scope.
+  (* Notation "' r1 .. rn '<-' t1 ';' t2" := (bind t1 (fun r1 => .. (fun rn => t2%tactic) ..)) *)
+  (*   (at level 20, r1 binder, rn binder, t1 at level 100, t2 at level 200, *)
+  (*    format "'[' ''' r1 .. rn  '<-'  '[' t1 ;  ']' ']' '/' t2 ") : tactic_scope. *)
+  Notation "' r '<-' t1 ';' t2" := (bind t1 (fun r=> t2%tactic))
+    (at level 20, r pattern, t1 at level 100, t2 at level 200,
+     right associativity, format "'[' ''' r  '<-'  '[' t1 ;  ']' ']' '/' t2 ") : tactic_scope.
   Notation "` r1 .. rn '<-' t1 ';' t2" := (bind t1 (fun r1 => .. (bind t1 (fun rn => t2%tactic)) ..))
     (at level 20, r1 binder, rn binder, t1 at level 100, t2 at level 200,
      right associativity, format "'[' '`' r1  ..  rn  '<-'  '[' t1 ;  ']' ']' '/' t2 ") : tactic_scope.

--- a/theories/tactics/Ttactics.v
+++ b/theories/tactics/Ttactics.v
@@ -42,26 +42,26 @@ Definition to_goal (A : Type) : M (A *m goal gs_open) :=
 (** [demote] is a [ttac] that proves anything by simply postponing it as a
     goal. *)
 Definition demote {A: Type} : ttac A :=
-  ''(m: a, g) <- to_goal A;
+  '(m: a, g) <- to_goal A;
   let '(Metavar _ g) := g in
   M.ret (m: a, [m: AnyMetavar _ g]).
 
 (** [use t] tries to solve the goal with tactic [t] *)
 Definition use {A} (t : tactic) : ttac A :=
-    ''(m: a, g) <- to_goal A;
+    '(m: a, g) <- to_goal A;
     gs <- t g;
     let gs := dreduce (@mmap) (mmap (fun '(m: _, g) => g) gs) in
     M.ret (m: a, gs).
 Arguments use [_] _%tactic.
 
 Definition idtac {A} : ttac A :=
-    ''(m: a, g) <- to_goal A;
+    '(m: a, g) <- to_goal A;
     let '(Metavar _ g) := g in
     M.ret (m: a, [m: AnyMetavar _ g]).
 
 (** [by'] is like [use] but it ensures there are no goals left. *)
 Definition by' {A} (t : tactic) : ttac A :=
-  ''(m: a, g) <- to_goal A;
+  '(m: a, g) <- to_goal A;
   gs <- t g;
   gs' <- T.filter_goals gs;
   match gs' with
@@ -80,7 +80,7 @@ Coercion lift : M.t >-> ttac.
 Definition fappgl {A B C} (comb : C -> C -> M C) (f : M ((A -> B) *m C)) (x : M (A *m C)) : M (B *m C) :=
   (f >>=
      (fun '(m: b, cb) =>
-        ''(m: a, ca) <- x;
+        '(m: a, ca) <- x;
         c <- comb cb ca;
         M.ret (m: b a, c)
      )
@@ -156,7 +156,7 @@ Definition vm_change_dep {X} (B : X -> Type) x {y} (f : ttac (B x)) : ttac (B y)
 Definition tintro {A P} (f: forall (x:A), ttac (P x))
   : ttac (forall (x:A), P x) :=
   M.nu (FreshFrom f) mNone (fun x=>
-    ''(m: v, gs) <- f x;
+    '(m: v, gs) <- f x;
     a <- M.abs_fun x v;
     b <- T.close_goals x (mmap (fun g=>(m: tt, g)) gs);
     let b := mmap msnd b in
@@ -181,24 +181,24 @@ Definition reflexivity {P} {A B : P} : TT.ttac (A = B) :=
 Require Import Strings.String.
 
 Definition ucomp1 {A B} (t: ttac A) (u: ttac B) : ttac A :=
-  ''(m: v1, gls1) <- t;
+  '(m: v1, gls1) <- t;
   match gls1 with
   | [m: gl] =>
-    ''(m: v2, gls) <- u;
+    '(m: v2, gls) <- u;
     open_and_apply (exact v2) gl;;
     M.ret (m: v1, gls)
   | _ => mfail "more than a goal"%string
   end.
 
 Definition lower {A} (t: ttac A) : M A :=
-  ''(m: r, _) <- t;
+  '(m: r, _) <- t;
   ret r.
 
 
 (** [rewrite] allows to rewrite with an equation in a specific part of the goal. *)
 Definition rewrite {X : Type} (C : X -> Type) {a b : X} (H : a = b) :
   ttac (C b) -> ttac (C a) := fun t =>
-  ''(m: x, gs) <- t;
+  '(m: x, gs) <- t;
   M.ret (m:
           match H in _ = z return (C z) -> (C a) with
           | eq_refl => fun x => x
@@ -212,14 +212,14 @@ Definition rewrite {X : Type} (C : X -> Type) {a b : X} (H : a = b) :
 Definition with_goal_prop (F : forall (P : Prop), ttac P) : tactic := fun g =>
   match g with
   | @Metavar Propₛ G g =>
-    ''(m: x, gs) <- F G;
+    '(m: x, gs) <- F G;
     M.cumul_or_fail UniCoq x g;;
     M.map (fun g => M.ret (m:tt,g)) gs
   | @Metavar Typeₛ G g =>
     gP <- evar Prop;
     mtry
       cumul_or_fail UniMatch gP G;;
-      ''(m: x, gs) <- F gP;
+      '(m: x, gs) <- F gP;
       M.cumul_or_fail UniCoq x g;;
       M.map (fun g => M.ret (m:tt,g)) gs
     with _ => raise CantCoerce end (* its better to raise CantCoerce than NotCumul *)
@@ -231,14 +231,14 @@ Definition with_goal_prop (F : forall (P : Prop), ttac P) : tactic := fun g =>
 Definition with_goal_type (F : forall (T : Type), ttac T) : tactic := fun g =>
   match g with
   | @Metavar Propₛ G g =>
-    ''(m: x, gs) <- F G;
+    '(m: x, gs) <- F G;
     M.cumul_or_fail UniCoq x g;;
     M.map (fun g => M.ret (m:tt,g)) gs
   | @Metavar Typeₛ G g =>
     gP <- evar Prop;
     mtry
       cumul_or_fail UniMatch gP G;;
-      ''(m: x, gs) <- F G;
+      '(m: x, gs) <- F G;
       M.cumul_or_fail UniCoq x g;;
       M.map (fun g => M.ret (m:tt,g)) gs
     with _ => raise CantCoerce end (* its better to raise CantCoerce than NotCumul *)
@@ -249,7 +249,7 @@ Definition with_goal_sort (F : forall {s : Sort} (T : s), ttac T) (e : Exception
   fun g =>
     match g with
     | @Metavar s T g =>
-      ''(m: t, gs) <- F T;
+      '(m: t, gs) <- F T;
       o <- M.unify g t UniMatchNoRed;
       match o with
       | mSome _ =>
@@ -295,7 +295,7 @@ Fixpoint match_goal_pattern'
           o <- M.unify_univ P G u;
           match o with
           | mSome f =>
-            ''(m: p, gs) <- t;
+            '(m: p, gs) <- t;
             let fp := reduce (RedOneStep [rl:RedBeta]) (f p) in
             M.ret (m: fp, gs)
           | mNone => raise DoesNotMatchGoal


### PR DESCRIPTION
This also fixes a weird inconsistency between the notations for `tactic` and `M`.