### PR TITLE
Remove `Check` notation.

### DIFF
--- a/theories/Base.v
+++ b/theories/Base.v
@@ -42,7 +42,6 @@ Definition binder_exception (f: unit->unit) := M.get_binder_name f >>= new_excep
 Notation "'New' 'Exception' n" := (binder_exception (fun n=>n)) (at level 0, n at next level).
 
 Definition Check {A} (x:A) := M.print_term A.
-Notation "'Check' n" := (Check n) (at level 0).
 
 Definition Set_Debug_Exceptions := M.set_debug_exceptions true.
 Definition Unset_Debug_Exceptions := M.set_debug_exceptions false.


### PR DESCRIPTION
The notation is no longer necessary because `Mtac Do` has been changed
to no longer require parentheses around its argument. (Additionally, the
`Check` notation also made it impossible to `Locate` the `Check`
definition.)