### PR TITLE
Adapt to coq/coq#8730 (unicode LM category allowed in idents)

### DIFF
--- a/theories/intf/Sorts.v
+++ b/theories/intf/Sorts.v
@@ -6,14 +6,14 @@ Set Universe Polymorphism.
 Unset Universe Minimization ToSet.
 
 
-Reserved Notation "Typeₛ".
-Reserved Notation "Propₛ".
+Reserved Notation "'Typeₛ'".
+Reserved Notation "'Propₛ'".
 Module S.
 
 Monomorphic Inductive Sort : Type := Prop_sort | Type_sort.
 
-Notation "Typeₛ" := Type_sort.
-Notation "Propₛ" := Prop_sort.
+Notation "'Typeₛ'" := Type_sort.
+Notation "'Propₛ'" := Prop_sort.
 
 (** Creates a fresh type according to [s] *)
 Definition stype_of (s : Sort) : Type :=
@@ -88,9 +88,9 @@ Import S.
 
 Declare Scope Sort_scope.
 Delimit Scope Sort_scope with sort.
-Notation "Typeₛ" := Type_sort.
-Notation "Propₛ" := Prop_sort.
-Notation "forallₛ  x .. y ,  T" :=
+Notation "'Typeₛ'" := Type_sort.
+Notation "'Propₛ'" := Prop_sort.
+Notation "'forallₛ'  x .. y ,  T" :=
   (ForAll (fun x => .. (fun y => T) ..))
     (at level 200, x binder, y binder) : Sort_scope.
 Notation "∀ₛ  x .. y ,  T" :=
@@ -99,10 +99,10 @@ Notation "∀ₛ  x .. y ,  T" :=
 Notation "S ->ₛ T" :=
   (∀ₛ _ : S, T)%sort
     (at level 200) : Sort_scope.
-Notation "funₛ  x .. y =>  t" :=
+Notation "'funₛ'  x .. y =>  t" :=
   (Fun (fun x => .. (fun y => t) ..))
     (at level 200, x binder, y binder) : Sort_scope.
-Notation "λₛ  x .. y ,  t" :=
+Notation "'λₛ'  x .. y ,  t" :=
   (Fun (fun x => .. (fun y => t) ..))
     (at level 200, x binder, y binder) : Sort_scope.
 


### PR DESCRIPTION
This makes `Notation "Typeₛ" := ...` fail as Typeₛ is an ident.
The solution I picked is to define `Inductive Sort : Type := Propₛ |
Typeₛ.` directly.

Alternatively we could do `Notation "'Typeₛ'" := ...`, I think that
would be backward compatible.