### PR TITLE
Remove visible `selem_of` from `TT.match_goal`.

### DIFF
--- a/tests/ttactics.v
+++ b/tests/ttactics.v
@@ -64,3 +64,29 @@ Mtac Do (
                            )
                             (* M.unify_or_fail UniMatchNoRed t (id (fun a : True => a <: True) I) *)
      )%MC.
+
+
+(* Testing the *type* of the goal in [match_goal] for the absence of [S.selem_of] and other unwanted wrappers. *)
+Module SelemOf.
+  Import TT.
+  Definition test_Type := (
+        match_goal with | [[?P |- P]] =>
+          mmatch P return M (P *m _) with
+          | unit =n> TT.idtac : M _
+          | _ => mfail "[P] not forwarded as exactly [P] to [match_goal] branch"
+          end
+        end)%MC%TT.
+  Definition test_Prop := (
+        match_goal with | [[?P : Prop |- P]] =>
+          mmatch P return M (P *m _) with
+          | True =n> TT.idtac : M _
+          | _ => mfail "[P] not forwarded as exactly [P] to [match_goal] branch"
+          end
+        end)%MC%TT.
+  Goal unit.
+    mrun test_Type.
+  Abort.
+  Goal True.
+    mrun test_Prop.
+  Abort.
+End SelemOf.


### PR DESCRIPTION
The type passed to the continuation was wrapped in `selem_of` since 80589fa40caf5697824e0762b8aeac935b378cb3. tests/ttactics.v now contains a test to avoid future regressions.

bors r+