### PR TITLE
Make `T.generalize` create new evar in ctx w/o `x`.

### DIFF
--- a/theories/tactics/Tactics.v
+++ b/theories/tactics/Tactics.v
@@ -140,7 +140,7 @@ Definition generalize {A} (x : A) : tactic := fun g =>
   match g with
   | Metavar Typeₛ P _ =>
      aP <- M.abs_prod_type x P; (* aP = (forall x:A, P) *)
-     e <- M.evar aP;
+     e <- M.remove x (M.evar aP);
      mmatch aP with
      | [? Q : A -> Type] (forall z:A, Q z) =n> [H]
         let e' := reduce (RedWhd [rl:RedMatch]) match H in _ =m= Q return Q with meq_refl _ => e end in
@@ -150,7 +150,7 @@ Definition generalize {A} (x : A) : tactic := fun g =>
      end
   | Metavar Propₛ P _ =>
      aP <- M.abs_prod_prop x P; (* aP = (forall x:A, P) *)
-     e <- M.evar aP;
+     e <- M.remove x (M.evar aP);
      mmatch aP with
      | [? Q : A -> Prop] (forall z:A, Q z) =n> [H]
         let e' := reduce (RedWhd [rl:RedMatch]) match H in _ =m= Q return Q with meq_refl _ => e end in


### PR DESCRIPTION
This facilitates interaction between `M` and `tactic` code. Previously, `T.generalize` inside a `\nu x` would always generate the new evar with `x` in its context. Thus, the whole `\nu` block would eventually fail because `x` still appeared in the resulting value.