### PR TITLE
Adapting to Coq PR#10231 (change of internal representation of manual implicit arguments).

### DIFF
--- a/src/run.ml
+++ b/src/run.ml
@@ -924,20 +924,19 @@ let run_declare_implicits env sigma gr impls =
      But we do not care much for the actual type so right now we just take the constructor_pos
   *)
   let impliciteness = [|
-    (false, false, false)       (* Dummy value *)
-  ; (false, true, true)   (* Implicit *)
-  ; (true, true, true)    (* Maximal *)
+    false   (* Dummy value *)
+  ; false   (* Implicit *)
+  ; true    (* Maximal *)
   |]
   in
   let gr = Globnames.global_of_constr gr in
   let impls = CoqList.from_coq sigma env impls in
-  let impls = List.rev impls in
   let idx = ref (List.length impls) in
   let impls = List.map
                 (fun item ->
                    let kind_pos = get_constructor_pos sigma item in
-                   let ret = (if kind_pos > 0 then
-                                Some (Constrexpr.ExplByPos(!idx, None), impliciteness.(kind_pos))
+                   let ret = CAst.make (if kind_pos > 0 then
+                                Some (Anonymous, impliciteness.(kind_pos))
                               else
                                 None) in
                    (* let ret = match CoqOption.from_coq (env, sigma) item with *)
@@ -948,7 +947,6 @@ let run_declare_implicits env sigma gr impls =
                    (* in *)
                    idx := !idx - 1; ret
                 ) impls in
-  let impls = List.map_filter (fun x -> x) impls in
   (* since there is no way to declare something explicit, we clear implicits first *)
   let () = Impargs.declare_manual_implicits false gr [] in
   let () = Impargs.maybe_declare_manual_implicits false gr impls in


### PR DESCRIPTION
Hi, this PR is adapting Mtac2 code to a change of representation of manual implicit arguments in coq/coq#10231. Dynamic invariants have been replaced by static ones and the unordered list of positions to make implicit has been replaced by a full ordered list of positions with `None` in positions not to be make implicit and `Some` in positions to make implicit (apparently, this slightly simplifies the Mtac2 code).  A location has also been added for error reporting.

The PR has to be merged simultaneously to coq/coq#10231.
