### PR TITLE
Adapting to Coq PR #8726 (more structured "locality" type).

### DIFF
--- a/src/run.ml
+++ b/src/run.ml
@@ -907,7 +907,7 @@ let run_declare_def env sigma kind name opaque ty bod =
   let id = Names.Id.of_string name in
   let kn = Declare.declare_definition ~opaque:opaque ~kind:kind id ~types:ty (bod, ctx) in
   let gr = Globnames.ConstRef kn in
-  let () = Lemmas.call_hook ~fix_exn ?hook:(vernac_definition_hook false kind) uctx [] Global gr  in
+  let () = Lemmas.call_hook ~fix_exn ?hook:(vernac_definition_hook false kind) uctx [] (Global ImportDefaultBehavior) gr  in
   let c = UnivGen.constr_of_monomorphic_global gr in
   let env = Global.env () in
   (* Feedback.msg_notice *)


### PR DESCRIPTION
The change is that flag `Global` becomes `Global ImportDefaultBehavior` so as to distinguish it from the kind of globality which does not import the qualified names. See coq/coq#8726.

Note: To be merged synchronously with coq/coq#8726.