### PR TITLE
Compatibility with Coq async proofs

### DIFF
--- a/src/mConstr.ml
+++ b/src/mConstr.ml
@@ -151,9 +151,9 @@ let num_args_of_mconstr (type a) (mh : a mconstr_head) =
 
 let _mkconstr s = lazy (let (_, c) = mkUConstr ("M.M." ^ s) Evd.empty (Global.env ()) in c)
 let _isconstr c h = eq_constr_nounivs Evd.empty (Lazy.force c) h
-let isconstant n h = Names.Constant.equal n h
+let isconstant n h = Names.Constant.equal (Lazy.force n) h
 
-let constant_of_string s = constant_of_string ("M.M." ^ s)
+let constant_of_string s = lazy (constant_of_string ("M.M." ^ s))
 
 let name_ret = constant_of_string "ret"
 (* let mkret = mkconstr name_ret *)

--- a/theories/Base.v
+++ b/theories/Base.v
@@ -1,12 +1,16 @@
-From Mtac2 Require Import Logic Datatypes Logic List Utils Sorts MTele.
-Import Sorts.
-From Mtac2 Require Export Pattern.
-From Mtac2.intf Require Export Dyn Reduction Unification DeclarationDefs M Lift .
-
 (* Need to load Unicoq to get the module dependency right *)
 Declare ML Module "unicoq".
 (** Load library "MetaCoqPlugin.cma". *)
 Declare ML Module "MetaCoqPlugin".
+
+(* Declare ML Module must work without the Requires to be compatible
+   with async proofs. Running it before them serves as a test
+   (although it doesn't test that it still works without the prelude
+   Requires). *)
+From Mtac2 Require Import Logic Datatypes Logic List Utils Sorts MTele.
+Import Sorts.
+From Mtac2 Require Export Pattern.
+From Mtac2.intf Require Export Dyn Reduction Unification DeclarationDefs M Lift .
 
 Require Import Strings.String.
 Require Import NArith.BinNat.


### PR DESCRIPTION
This allows for instance running the following in Coqide with "go to end":
~~~coq
From Mtac2 Require Import  Tactics.

Definition SimpleRewriteNoOccurrence : Exception. constructor. Qed.
~~~

The issue is that the constant_of_string calls happen at linking time,
but in proof workers the state is installed after linking plugins.

I also removed some fix_exn nonsense because it confused me while
investigating. This removes all references to Future from mtac code. (Future.from_val makes a dummy fix_exn.)

I don't know how to test the possible perf impact.