### PR TITLE
Rework `M.constrs`.

### DIFF
--- a/src/constrs.ml
+++ b/src/constrs.ml
@@ -482,3 +482,19 @@ module CoqSort = struct
 
 
 end
+
+module CoqInd_Dyn = struct
+  open UConstrBuilder
+  let mkInd_dyn = from_string "Mtac2.intf.Case.mkInd_dyn"
+
+  exception NotAmkInd_dyn
+
+  let from_coq sigma env cterm =
+    match from_coq mkInd_dyn (env, sigma) cterm with
+    | None -> raise NotAmkInd_dyn
+    | Some args -> args
+
+  let to_coq sigma env =
+    build_app mkInd_dyn sigma env
+
+end

--- a/src/constrs.mli
+++ b/src/constrs.mli
@@ -170,3 +170,11 @@ module CoqSort : sig
   val to_coq :
     Evd.evar_map -> Environ.env -> sort -> Evd.evar_map * EConstr.t
 end
+
+module CoqInd_Dyn : sig
+  exception NotAmkInd_dyn
+  val from_coq : Evd.evar_map -> 'a -> EConstr.t -> EConstr.t array
+  val to_coq :
+    Evd.evar_map ->
+    Environ.env -> EConstr.t array -> Evd.evar_map * EConstr.t
+end

--- a/src/run.ml
+++ b/src/run.ml
@@ -936,9 +936,9 @@ let run_declare_implicits env sigma gr impls =
                 (fun item ->
                    let kind_pos = get_constructor_pos sigma item in
                    let ret = CAst.make (if kind_pos > 0 then
-                                Some (Anonymous, impliciteness.(kind_pos))
-                              else
-                                None) in
+                                          Some (Anonymous, impliciteness.(kind_pos))
+                                        else
+                                          None) in
                    (* let ret = match CoqOption.from_coq (env, sigma) item with *)
                    (*   | None -> None *)
                    (*   | Some item -> *)

--- a/src/run.ml
+++ b/src/run.ml
@@ -633,11 +633,11 @@ let get_Constrs (env, sigma) t =
     let mbody = Environ.lookup_mind mind env in
     let ind = Array.get (mbody.mind_packets) ind_i in
     let sigma, dyn = mkdyn sigma env in
-    let args = CList.firstn mbody.mind_nparams_rec args in
+    (* let args = CList.firstn mbody.mind_nparams_rec args in *)
     let sigma, l = Array.fold_right
                      (fun i (sigma, l) ->
                         let constr = Names.ith_constructor_of_inductive (mind, ind_i) i in
-                        let coq_constr = applist (mkConstruct constr, args) in
+                        let coq_constr = mkConstruct constr in
                         let ty = Retyping.get_type_of env sigma coq_constr in
                         let sigma, dyn_constr = mkDyn ty coq_constr sigma env in
                         CoqList.mkCons sigma env dyn dyn_constr l
@@ -646,12 +646,15 @@ let get_Constrs (env, sigma) t =
                      (Array.mapi (fun i t -> i+1) ind.mind_consnames)
                      (CoqList.mkNil sigma env dyn)
     in
-    let indty = applist (t_type, args) in
+    let indty = t_type in
     let indtyty = Retyping.get_type_of env sigma indty in
+    let nparams = CoqN.to_coq (mbody.mind_nparams) in
+    let nindices = CoqN.to_coq (ind.mind_nrealargs) in
     let sigma, indtydyn = mkDyn indtyty indty sigma env in
-    let sigma, listty = CoqList.mkType sigma env dyn in
-    let sigma, pair = CoqPair.mkPair sigma env dyn listty indtydyn l in
-    Some (sigma, pair)
+    let sigma, ind_dyn = CoqInd_Dyn.to_coq sigma env [|indtydyn; nparams; nindices; l|] in
+    (* let sigma, listty = CoqList.mkType sigma env dyn in
+     * let sigma, pair = CoqPair.mkPair sigma env dyn listty indtydyn l in *)
+    Some (sigma, ind_dyn)
   else
     None
 

--- a/tests/DepDestruct.v
+++ b/tests/DepDestruct.v
@@ -192,8 +192,9 @@ Abort.
 End ExampleReflect.
 
 Set Unicoq Try Solving Eqn.
+Require Vector.
 Module VectorExample.
-Require Import Vector.
+Import Vector.
 Goal forall n (v : t nat n), n = Coq.Lists.List.length (to_list v).
 Proof.
   pose (it := iTele (fun n => @iBase (Typeₛ) (t nat n))).

--- a/tests/Exhaustive.v
+++ b/tests/Exhaustive.v
@@ -41,20 +41,16 @@ Fail Check (mmatch 1 exhaustively_with
       | [#] O | =n> M.print "O"
       end).
 
-(* Check inductive type with parameter. *)
+(* Check inductive type with parameters. *)
 Check (mmatch cons 1 nil exhaustively_with
       | [#] @nil _ | =n> M.print "nil"
       | [#] @cons _ | a l =n> M.print "cons"
       | _ => M.print "not in constructor normal form"
       end).
 
-(* Type inference works backworks so a syntactically different parameter later
-in the list will be used for elided parameters earlier and thus might throw off
-the exhaustiveness checker. Here, we make the parameter for [cons] [id nat]
-instead of just [nat]. The [_] for the parameter of [nil] will also be [id nat]
-and thus the checker will find neither constructor. *)
-Fail Check (mmatch cons 1 nil exhaustively_with
-      | [#] @nil _ | =n> M.print "nil"
-      | [#] @cons (id nat) | a l =n> M.print "cons"
+(* Check inductive type with parameters which we instantiate with syntactically different but convertible values. *)
+Check (mmatch cons 1 nil exhaustively_with
+      | [#] @nil (id nat) | =n> M.print "nil"
+      | [#] @cons nat | a l =n> M.print "cons"
       | _ => M.print "not in constructor normal form"
       end).

--- a/theories/ideas/Transport.v
+++ b/theories/ideas/Transport.v
@@ -17,13 +17,9 @@ Fixpoint combine {A B} (l : mlist A) (l' : mlist B) {struct l} : mlist (A *m B) 
   end.
 
 Definition get_ind_cts (A : Type) (offset : nat) : M (nat * {s : Sort & { it : ITele s & mlist (NDCTele it)}}) :=
-  ind <- get_ind A;
-  let (nsortit, constrs) := ind in
-  (* drop first `offset` constructors. *)
+    '(m: nparams, nindx, (existT _ isort it), constrs) <- get_ind A;
   let constrs := mskipn offset constrs in
-  let (nindx, sortit) := nsortit in
-  let (isort, it) := sortit in
-  atele <- get_ind_atele it nindx A;
+  atele <- get_ind_atele it nparams nindx A;
                (* Compute CTeles *)
   cts <- M.map (fun c_dyn : dyn =>
     dcase c_dyn as dtype, delem in

--- a/theories/intf/Case.v
+++ b/theories/intf/Case.v
@@ -1,8 +1,18 @@
+From Coq Require Import BinNums.
 From Mtac2 Require Import List.
 From Mtac2.intf Require Import Dyn.
 
 Set Universe Polymorphism.
 Unset Universe Minimization ToSet.
+Set Polymorphic Inductive Cumulativity.
+
+Record Ind_dyn :=
+  mkInd_dyn {
+      ind_dyn_ind : dyn;
+      ind_dyn_nparams : N;
+      ind_dyn_nindices : N;
+      ind_dyn_constrs : mlist dyn
+    }.
 
 Record Case :=
     mkCase {

--- a/theories/intf/M.v
+++ b/theories/intf/M.v
@@ -177,7 +177,7 @@ Definition destcase: forall{A: Type} (a: A), t (Case).
 (** Given an inductive type A, applied to all its parameters (but not
     necessarily indices), it returns the type applied to exactly the
     parameters, and a list of constructors (applied to the parameters). *)
-Definition constrs: forall{A: Type} (a: A), t (mprod dyn (mlist dyn)).
+Definition constrs: forall{A: Type} (a: A), t Ind_dyn.
   make. Qed.
 
 Definition makecase: forall(C: Case), t dyn.

--- a/theories/intf/M.v
+++ b/theories/intf/M.v
@@ -175,8 +175,13 @@ Definition destcase: forall{A: Type} (a: A), t (Case).
   make. Qed.
 
 (** Given an inductive type A, applied to all its parameters (but not
-    necessarily indices), it returns the type applied to exactly the
-    parameters, and a list of constructors (applied to the parameters). *)
+    necessarily indices), [constrs] returns a [Ind_dyn] value representing the
+    inductive type:
+    - [ind_dyn_ind]: The unapplied inductive type itself as a [dyn]
+    - [ind_dyn_nparams]: The number of parameters
+    - [ind_dyn_nindices]: The number of indices
+    - [ind_dyn_constrs]: the inductie type's constructors as [dyn]s
+. *)
 Definition constrs: forall{A: Type} (a: A), t Ind_dyn.
   make. Qed.
 

--- a/theories/meta/Exhaustive.v
+++ b/theories/meta/Exhaustive.v
@@ -1,5 +1,6 @@
-From Mtac2 Require Import Base List.
+From Mtac2 Require Import Base List Datatypes.
 Import M.notations.
+Import Datatypes.ProdNotations.
 
 
 Set Universe Polymorphism.
@@ -21,6 +22,8 @@ Definition find_in_constrs {C} (c : C)  : mlist dyn -> M (mlist dyn) :=
     match cs with
     | mnil => M.ret mnil
     | mcons c' cs =>
+      '(m: c, _) <- M.decompose c;
+      dcase c as C, c in
       let C := reduce (RedVmCompute) C in
       mmatch c' with
       | @Dyn C c =n> M.ret cs
@@ -33,7 +36,7 @@ Definition check_exhaustiveness {A B y}
            (ps_in : mlist (branch M A B y))
            (ops : moption (mlist (branch M A B y))) :
   M (mlist (branch M A B y)) :=
-  '(mpair _ constrs) <- M.constrs A;
+  '(mkInd_dyn _ _ _ constrs) <- M.constrs A;
   (
     mfix2 f (ps : _) (constrs : _) : M _ :=
       match ps, constrs with

--- a/theories/tactics/ConstrSelector.v
+++ b/theories/tactics/ConstrSelector.v
@@ -30,9 +30,8 @@ Definition get_constrs :=
         fill (P x)
       )
     | _ =>
-      l <- M.constrs T;
-      let (_, l') := l in
-      M.ret l'
+      '(mkInd_dyn _ _ _ l) <- M.constrs T;
+      M.ret l
     end%MC.
 
 (** Given a constructor c, it returns its index. *)


### PR DESCRIPTION
The new interface returns the inductive type and its constructors
*unapplied*. This means a bit more work on the Coq side of things to
re-apply parameters but it does simplify the OCaml code a bit and makes
the primitive work with inductives that are not applied to parameters.