### PR TITLE
Typecheck `Mtac Do` arguments before execution.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,3 +13,4 @@ Notation:
 Vernacular:
 
 - `Mtac Do` now accepts its argument without parentheses.
+- `Mtac Do` now typechecks its argument and only executes code of type `M _`.

--- a/src/metaCoqInterp.ml
+++ b/src/metaCoqInterp.ml
@@ -192,6 +192,19 @@ module MetaCoqRun = struct
       run env sigma concl evar istactic t
     end
 
+  let run_mtac_do env sigma t =
+    let sigma, t = Constrintern.interp_open_constr env sigma t in
+    let ty = Retyping.get_type_of env sigma t in
+    let sigma, (concl, sort) = Evarutil.new_type_evar env sigma Evd.univ_flexible in
+    let isM, sigma = ifM env sigma concl ty t in
+    if isM then
+      match Run.run (env, sigma) t with
+      | Run.Val _ -> ()
+      | Run.Err (_, e) ->
+          CErrors.user_err (str "Uncaught exception: " ++ Printer.pr_econstr_env env sigma e)
+    else
+      CErrors.user_err (str "Mtac Do expects a term of type [M _].")
+
   let run_cmd env sigma t =
     let sigma, c = Constrintern.interp_open_constr env sigma t in
     match Run.run (env, sigma) c with

--- a/src/metaCoqInterp.mli
+++ b/src/metaCoqInterp.mli
@@ -14,6 +14,9 @@ type mrun_arg =
 module MetaCoqRun : sig
   val run_tac_constr : mrun_arg -> unit Proofview.tactic
 
+  val run_mtac_do :
+    Environ.env -> Evd.evar_map -> Constrexpr.constr_expr -> unit
+
   val run_cmd : Environ.env -> Evd.evar_map -> Constrexpr.constr_expr -> unit
 end
 

--- a/src/metaCoqTactic.mlg
+++ b/src/metaCoqTactic.mlg
@@ -44,6 +44,6 @@ VERNAC COMMAND EXTEND MtacDo CLASSIFIED AS SIDEFF
     fun ~pstate ->
     let sigma, env = Option.cata Pfedit.get_current_context
                        (let e = Global.env () in Evd.from_env e, e) pstate in
-    MetaCoqRun.run_cmd env sigma c
+    MetaCoqRun.run_mtac_do env sigma c
   }
 END

--- a/tests/test_mmatch.v
+++ b/tests/test_mmatch.v
@@ -216,14 +216,14 @@ Mtac Do (
              (m :=MTele.mTele (fun x : nat => MTele.mTele (fun y : nat => MTele.mBase)))
              UniMatchNoRed
              plus
-             (fun x y => M.unify_or_fail UniMatchNoRed (x,y) (3,5))
+             (fun x y => M.unify_or_fail UniMatchNoRed (x,y) (3,5);; M.ret I)
       end
      ).
 
 (* With nice syntax *)
 Mtac Do (
        mmatch (3 + 5) with
-       | [#] plus | x y =n> M.unify_or_fail UniMatchNoRed (x,y) (3,5)
+       | [#] plus | x y =n> M.unify_or_fail UniMatchNoRed (x,y) (3,5);; M.ret I
       end
      ).
 
@@ -231,8 +231,8 @@ Mtac Do (
 (* Checking notation levels *)
 Mtac Do (
        mmatch (3 + 5) with
-       | [#] plus | x y =n> _ <- M.ret tt; M.unify_or_fail UniMatchNoRed (x,y) (3,5)
-       | [#] plus | x y =n> M.ret tt;; M.unify_or_fail UniMatchNoRed (x,y) (3,5)
+       | [#] plus | x y =n> _ <- M.ret tt; M.unify_or_fail UniMatchNoRed (x,y) (3,5);; M.ret I
+       | [#] plus | x y =n> M.ret tt;; M.unify_or_fail UniMatchNoRed (x,y) (3,5);; M.ret I
       end
      ).
 
@@ -240,20 +240,20 @@ Mtac Do (
    arguments *)
 Fail Mtac Do (
        mmatch (3 + 3) with
-       | [#] plus (2+1) | y =n> M.unify_or_fail UniMatchNoRed (y) (5)
+       | [#] plus (2+1) | y =n> M.unify_or_fail UniMatchNoRed (y) (5);; M.ret I
       end
      ).
 (* But this one succeeds, as it uses conversion by calling Unicoq's unification. *)
 Mtac Do (
        mmatch (3 + 5) with
-       | [#] plus (2+1) | y =u> M.unify_or_fail UniMatchNoRed (y) (5)
+       | [#] plus (2+1) | y =u> M.unify_or_fail UniMatchNoRed (y) (5);; M.ret I
       end
      ).
 
 (* [decompose_forall[P|T]] *)
 Mtac Do (
        mmatch (forall x : nat, x = x) with
-       | branch_forallP (fun X P => M.unify_or_fail UniMatchNoRed P (fun x => x = x))
+       | branch_forallP (fun X P => M.unify_or_fail UniMatchNoRed P (fun x => x = x);; M.ret I)
       end
      ).
 Mtac Do (
@@ -265,7 +265,7 @@ Mtac Do (
 (* With nice syntax *)
 Mtac Do (
        mmatch (forall x : nat, x = x) with
-       | [!Prop] forall _ : X, P =n> M.unify_or_fail UniMatchNoRed P (fun x => x = x)
+       | [!Prop] forall _ : X, P =n> M.unify_or_fail UniMatchNoRed P (fun x => x = x);; M.ret I
       end
      ).
 Mtac Do (


### PR DESCRIPTION
Some test cases in tests/test_mmatch.v were actually ill-typed before.
This has also been fixed.