### PR TITLE
Having @ in front of a notation variable was tolerated but is now an error.

### DIFF
--- a/theories/intf/Reduction.v
+++ b/theories/intf/Reduction.v
@@ -37,5 +37,5 @@ Notation rhnf := (reduce RedHNF).
 Notation rcbv := (reduce RedNF).
 Notation "'dreduce' ( l1 , .. , ln )" :=
   (reduce (RedStrong [rl:RedBeta; RedFix; RedMatch;
-           RedDeltaOnly (rlcons (Dyn (@l1)) ( .. (rlcons (Dyn (@ln)) rlnil) ..))]))
+           RedDeltaOnly (rlcons (Dyn l1) ( .. (rlcons (Dyn ln) rlnil) ..))]))
   (at level 0).


### PR DESCRIPTION
Hi, this PR is in anticipation of [Coq PR#11120](https://github.com/coq/coq/pull/11120) which in particular addresses [Coq issue#4690](https://github.com/coq/coq/pull/4690).

In notations, `@` in front of a notation variable was a no-op. It is now an error.

This Mtac2 PR is backward compatible and can be merged as soon as now.