### PR TITLE
Restrict universes in M.declare.

### DIFF
--- a/src/constrs.ml
+++ b/src/constrs.ml
@@ -402,28 +402,6 @@ module CoqPair = struct
     | Some args -> (args.(2), args.(3))
 end
 
-module CoqPTele = struct
-  open UConstrBuilder
-
-  let pBaseBuilder = from_string "Mtac2.intf.MTele.pBase"
-  let pTeleBuilder = from_string "Mtac2.intf.MTele.pTele"
-
-  (* let mkType env sigma tele = build_app pTeleBuilder sigma env [|tele|] *)
-  let mkPBase env sigma tele = build_app pBaseBuilder sigma env [|tele|]
-  let mkPTele env sigma ty telefun tyval ptele = build_app pTeleBuilder sigma env [|ty; telefun; tyval; ptele|]
-
-  exception NotAPTele
-
-  let from_coq sigma env cterm =
-    match from_coq pTeleBuilder (env, sigma) cterm with
-    | None ->
-        begin match from_coq pBaseBuilder (env, sigma) cterm with
-        | None -> raise NotAPTele
-        | Some _ -> None
-        end
-    | Some args -> Some (args.(2), args.(3))
-end
-
 module CoqMTele = struct
   open UConstrBuilder
 

--- a/src/constrs.mli
+++ b/src/constrs.mli
@@ -138,16 +138,6 @@ module CoqPair : sig
   val from_coq : (Environ.env * Evd.evar_map) -> constr -> constr * constr
 end
 
-module CoqPTele : sig
-  exception NotAPTele
-
-  (* val mkType  : Environ.env -> Evd.evar_map -> constr -> Evd.evar_map * constr *)
-  val mkPBase : Environ.env -> Evd.evar_map -> constr -> Evd.evar_map * constr
-  val mkPTele : Environ.env -> Evd.evar_map -> types -> constr -> constr -> constr -> Evd.evar_map * constr
-
-  val from_coq : Evd.evar_map -> Environ.env -> constr -> (constr * constr) option
-end
-
 module CoqMTele : sig
   exception NotAnMTele
 

--- a/theories/intf/MTele.v
+++ b/theories/intf/MTele.v
@@ -324,26 +324,6 @@ Local Fixpoint MTele_id {s} (n : MTele) :
 
 Local Example map_id {s} {n : MTele} {A : MTele_Sort s n} := @MTele_map s n A A (MTele_id n).
 
-(** Partial Telescopes *)
-Inductive PTele : MTele -> Type :=
-| pBase {n} : PTele n
-| pTele {X} {F} (x : X) : PTele (F x) -> PTele (@mTele X F).
-
-Fixpoint PTele_MTele {n} (p : PTele n) : MTele :=
-  match p with
-  | pBase => n
-  | pTele _ p => PTele_MTele p
-  end.
-
-Coercion PTele_MTele : PTele >-> MTele.
-
-Fixpoint PTele_Sort {s} {n} (p : PTele n) : MTele_Sort s n -> MTele_Sort s p :=
-  match p with
-  | pBase => fun x => x
-  | pTele _ p => fun T => PTele_Sort p (T _)
-  end.
-
-
 
 (* Old MTele functions redefined on top of the more general newer ones above *)
 
@@ -369,12 +349,4 @@ Module TeleNotation.
       (x binder, z binder, format "[tele  '[hv' x  ..  z ']'  ]").
 
   Notation "'[tele' ]" := (mBase).
-
-  Notation "'[ptele' x , .. , z ]" :=
-    (pTele x .. (pTele z pBase) ..)
-      (format "[ptele  '[hv' x ,  .. ,  z ']'  ]").
-
-  Notation "'[ptele' ]" := (pBase).
-
-  (* Check [ptele 3, 5] : PTele [tele _ _ ]. *)
 End TeleNotation.


### PR DESCRIPTION
Previously every single call to `M.declare` introduced half a dozen monomorphic universes into the global universe graph that were not used anywhere.

bors r+