### PR TITLE
Implement backtraces for uncaught exceptions

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,4 +1,4 @@
-CAMLC = "ocamlc -c -rectypes -thread -warn-error +a"
+COQMF_WARN = "-warn-error +a-3-23"
 CAMLDEBUG = "-g"
 -arg -bt
 -I src

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (name MetaCoqPlugin)
  (public_name coq-mtac2.plugin)
- (flags :standard -rectypes -w -9-27 -warn-error -3)
+ (flags :standard -rectypes -w -9-27-23 -warn-error -3)
  (modules_without_implementation metaCoqInstr)
  (modules :standard \ machine)
  (libraries coq.plugins.ltac unicoq.plugin))

--- a/src/mConstr.ml
+++ b/src/mConstr.ml
@@ -503,6 +503,10 @@ let mconstr_head_of h =
       MHead Mdeclare_mind
   | _ -> raise Not_found
 
+let mconstr_head_opt h =
+  match mconstr_head_of h with
+  | mh -> Some(mh)
+  | exception Not_found -> None
 
 let mconstr_of (type a) args (h : a mconstr_head) =
   match h with

--- a/src/mConstr.mli
+++ b/src/mConstr.mli
@@ -87,4 +87,5 @@ and mconstr = | MConstr : 'a mconstr_head * 'a -> mconstr
 
 val num_args_of_mconstr : 'a mconstr_head -> int
 val mconstr_head_of : Names.Constant.t -> mhead
+val mconstr_head_opt : Names.Constant.t -> mhead option
 val mconstr_of : (int -> CClosure.fconstr) -> 'a mconstr_head -> mconstr

--- a/src/metaCoqInterp.ml
+++ b/src/metaCoqInterp.ml
@@ -71,7 +71,7 @@ module MetaCoqRun = struct
       str "Uncaught Mtac exception:\n"
       ++ str "  " ++ hov 2 (Printer.pr_econstr_env env sigma e)
       ++ str "\n" ++ str "Mtac backtrace (last function first):\n"
-      ++ Run.pr_traceback tr
+      ++ Run.pr_backtrace tr
       ++ str "End of backtrace\n"
       ++ str "(Backtraces are only recorded with [Set_Debug_Exceptions].)\n"
     in

--- a/src/metaCoqInterp.ml
+++ b/src/metaCoqInterp.ml
@@ -73,6 +73,7 @@ module MetaCoqRun = struct
       ++ str "\n" ++ str "Mtac backtrace (last function first):\n"
       ++ Run.pr_traceback tr
       ++ str "End of backtrace\n"
+      ++ str "(Backtraces are only recorded with [Set_Debug_Exceptions].)\n"
     in
     CErrors.user_err ?loc err
 

--- a/src/run.ml
+++ b/src/run.ml
@@ -585,7 +585,11 @@ type traceback = traceback_entry list
 
 module Traceback = struct
   let push entry tr =
-    entry :: tr
+    if !debug_ex then
+      entry :: tr
+    else
+      tr
+
   let rec push_mtry mtry_tr =
     match mtry_tr with
     | [] -> push (MTry None)

--- a/src/run.ml
+++ b/src/run.ml
@@ -563,7 +563,7 @@ type traceback_entry =
   | MTry of Names.Constant.t option
   | InternalNu of Names.Id.t
   | InternalException of Pp.t
-  | Anon of Loc.t option
+  (* | Anon of Loc.t option *)
 
 let pr_traceback_entry t =
   let open Pp in
@@ -576,9 +576,9 @@ let pr_traceback_entry t =
       ++ p ++ str ">"
   | InternalNu name ->
       str "<nu: " ++ str (Names.Id.to_string name) ++ str ">"
-  | Anon (Some loc) ->
-      str "??? (" ++ Topfmt.pr_loc loc ++ str ")"
-  | Anon (None) -> Pp.str "???"
+(* | Anon (Some loc) ->
+ *     str "??? (" ++ Topfmt.pr_loc loc ++ str ")"
+ * | Anon (None) -> Pp.str "???" *)
 
 type traceback = traceback_entry list
 

--- a/src/run.mli
+++ b/src/run.mli
@@ -2,7 +2,12 @@ open Environ
 open Evd
 open EConstr
 
-type elem_stack = (evar_map * CClosure.fconstr * CClosure.stack)
+
+type traceback
+val pr_traceback : traceback -> Pp.t
+
+
+type elem_stack = (Evd.evar_map * CClosure.fconstr * CClosure.stack * traceback)
 
 type elem = (evar_map * constr)
 
@@ -12,7 +17,7 @@ type data_stack =
 
 type data =
   | Val of elem
-  | Err of elem
+  | Err of elem * traceback
 
 val make_evar : evar_map -> env -> constr -> evar_map * constr (* used in metaCoqInterp *)
 
@@ -31,11 +36,15 @@ type ctxt = {
   sigma: Evd.evar_map;
   nus: int;
   stack: CClosure.stack;
+  traceback: traceback;
 }
 
-type vm = Code of CClosure.fconstr | Ret of CClosure.fconstr | Fail of CClosure.fconstr
-        | Bind of CClosure.fconstr | Try of (Evd.evar_map * CClosure.stack * CClosure.fconstr)
-        | Nu of (Names.Id.t * Environ.env * CClosure.fconstr)
+type vm = Code of CClosure.fconstr
+        | Ret of CClosure.fconstr
+        | Fail of CClosure.fconstr
+        | Bind of (CClosure.fconstr * traceback)
+        | Try of (Evd.evar_map * CClosure.stack * traceback * CClosure.fconstr)
+        | Nu of (Names.Id.t * Environ.env * CClosure.fconstr * traceback)
         | Rem of (Environ.env * CClosure.fconstr * bool)
 
 (* val run_fix : ctxt -> vm list -> CClosure.fconstr -> CClosure.fconstr array -> CClosure.fconstr -> CClosure.fconstr -> CClosure.fconstr array *)

--- a/src/run.mli
+++ b/src/run.mli
@@ -3,11 +3,11 @@ open Evd
 open EConstr
 
 
-type traceback
-val pr_traceback : traceback -> Pp.t
+type backtrace
+val pr_backtrace : backtrace -> Pp.t
 
 
-type elem_stack = (Evd.evar_map * CClosure.fconstr * CClosure.stack * traceback)
+type elem_stack = (Evd.evar_map * CClosure.fconstr * CClosure.stack * backtrace)
 
 type elem = (evar_map * constr)
 
@@ -17,7 +17,7 @@ type data_stack =
 
 type data =
   | Val of elem
-  | Err of elem * traceback
+  | Err of elem * backtrace
 
 val make_evar : evar_map -> env -> constr -> evar_map * constr (* used in metaCoqInterp *)
 
@@ -36,15 +36,15 @@ type ctxt = {
   sigma: Evd.evar_map;
   nus: int;
   stack: CClosure.stack;
-  traceback: traceback;
+  backtrace: backtrace;
 }
 
 type vm = Code of CClosure.fconstr
         | Ret of CClosure.fconstr
         | Fail of CClosure.fconstr
-        | Bind of (CClosure.fconstr * traceback)
-        | Try of (Evd.evar_map * CClosure.stack * traceback * CClosure.fconstr)
-        | Nu of (Names.Id.t * Environ.env * CClosure.fconstr * traceback)
+        | Bind of (CClosure.fconstr * backtrace)
+        | Try of (Evd.evar_map * CClosure.stack * backtrace * CClosure.fconstr)
+        | Nu of (Names.Id.t * Environ.env * CClosure.fconstr * backtrace)
         | Rem of (Environ.env * CClosure.fconstr * bool)
 
 (* val run_fix : ctxt -> vm list -> CClosure.fconstr -> CClosure.fconstr array -> CClosure.fconstr -> CClosure.fconstr -> CClosure.fconstr array *)

--- a/tests/exceptions.v
+++ b/tests/exceptions.v
@@ -4,6 +4,12 @@ Require Import Mtac2.Mtac2.
 Axiom block : M nat.
 
 Fail Definition block_fails := ltac:(mrun block).
+Fail Definition block_fails2 := ltac:(mrun (id block)).
+Fail Definition block_fails3 := ltac:((mrun (match 0+0 with 0 => block | _ => M.ret 0 end))).
+Fail Definition block_fails4 :=
+  ltac:(mrun (
+            mtry id (M.raise exception;; M.ret 0) with | exception => id id block end
+       )%MC).
 
 Definition block_raises_failure :=
   ltac:(mrun (mtry block with StuckTerm => M.ret 0 end)%MC).


### PR DESCRIPTION
This PR implements backtraces for uncaught exceptions. The traces are only recorded with `Set_Debug_Exceptions` to avoid paying a cost in code that is not being debugged right now.

The backtraces contain all constants unfolded *directly* on the path to where the uncaught exception is raised. In particular, that means `id (ret tt);; raise exception` will not show `id` in the trace whereas `id (M.raise exception)` will. 

Some internal stack entries such as `nu` and `mtry` as well as internal interpreter exceptions are marked as such in the output.

The traces are printed in reverse order which may or may not be confusing but the output indicates the order as well as the requirement to turn on `Set_Debug_Exceptions`.

The feature as a whole could be improved upon by having whitelists/blacklists for entire modules to avoid the trace being filling up by countless helper functions from M.v and, even worse, Tactics.v. Additionally, I find the linear visualisation somewhat lacking given that the trace is actually a tree (leave nodes are exceptions that lead back to earlier handler nodes, except for the last one which is uncaught) but other PLs don't do this any differently and I couldn't find an approach to visualising the structure without introducing too much noise.