### PR TITLE
Implement support for `Existing Instance`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 Changes from 1.1 to 1.2
 =======================
 
+Primitives:
+
+- Added the `existing_instance` primitive that mirrors Coq's `Existing Instance`
+  vernacular. Together with `declare`, `existing_instance` can be used to
+  declare type class instances.
+
+
 Debugging:
 
 - `Set_Debug_Exceptions` now enables backtraces for uncaught exceptions. The

--- a/src/mConstr.ml
+++ b/src/mConstr.ml
@@ -85,6 +85,7 @@ type 'a mconstr_head =
   | Mkind_of_term : (arg_type * arg_any) mconstr_head
   | Mreplace : (arg_type * arg_type * arg_type * arg_any * arg_any * arg_any) mconstr_head
   | Mdeclare_mind : (arg_any * arg_any * arg_any) mconstr_head
+  | Mexisting_instance : (arg_any * arg_any * arg_bool) mconstr_head
 and mhead = | MHead : 'a mconstr_head -> mhead
 and mconstr = | MConstr : 'a mconstr_head * 'a -> mconstr
 
@@ -147,6 +148,7 @@ let num_args_of_mconstr (type a) (mh : a mconstr_head) =
   | Mkind_of_term -> 2
   | Mreplace -> 6
   | Mdeclare_mind -> 3
+  | Mexisting_instance -> 3
 
 
 let _mkconstr s = lazy (let (_, c) = mkUConstr ("M.M." ^ s) Evd.empty (Global.env ()) in c)
@@ -384,6 +386,9 @@ let isreplace = isconstant name_replace
 let name_declare_mind = constant_of_string "declare_mind"
 let isdeclare_mind = isconstant name_declare_mind
 
+let name_existing_instance = constant_of_string "existing_instance"
+let isexisting_instance = isconstant name_existing_instance
+
 
 let mconstr_head_of h =
   match h with
@@ -501,6 +506,8 @@ let mconstr_head_of h =
       MHead Mreplace
   | _ when isdeclare_mind h ->
       MHead Mdeclare_mind
+  | _ when isexisting_instance h ->
+      MHead Mexisting_instance
   | _ -> raise Not_found
 
 let mconstr_head_opt h =
@@ -650,3 +657,5 @@ let mconstr_of (type a) args (h : a mconstr_head) =
       MConstr (Mreplace, (args 0, args 1, args 2, args 3, args 4, args 5))
   | Mdeclare_mind ->
       MConstr (Mdeclare_mind, (args 0, args 1, args 2))
+  | Mexisting_instance ->
+      MConstr (Mexisting_instance, (args 0, args 1, args 2))

--- a/src/mConstr.mli
+++ b/src/mConstr.mli
@@ -82,6 +82,7 @@ type 'a mconstr_head =
   | Mkind_of_term : (arg_type * arg_any) mconstr_head
   | Mreplace : (arg_type * arg_type * arg_type * arg_any * arg_any * arg_any) mconstr_head
   | Mdeclare_mind : (arg_any * arg_any * arg_any) mconstr_head
+  | Mexisting_instance : (arg_any * arg_any * arg_bool) mconstr_head
 and mhead = | MHead : 'a mconstr_head -> mhead
 and mconstr = | MConstr : 'a mconstr_head * 'a -> mconstr
 

--- a/src/run.ml
+++ b/src/run.ml
@@ -2112,6 +2112,16 @@ and primitive ctxt vms mh reduced_term =
   | MConstr (Mdeclare_mind, (params, inds, constrs)) ->
       let sigma, types = declare_mind env sigma (to_econstr params) (to_econstr inds) (to_econstr constrs) in
       ereturn sigma types
+  | MConstr (Mexisting_instance, (name, prio, global)) ->
+      let global = CoqBool.from_coq sigma (to_econstr global) in
+      let name = CoqString.from_coq (env, sigma) (to_econstr name) in
+      let path = Libnames.path_of_string name in
+      let qualid = Libnames.qualid_of_path path in
+      let prio = CoqOption.from_coq sigma env (to_econstr prio) in
+      let open Typeclasses in
+      let hint_priority = Option.map (CoqN.from_coq (env, sigma)) prio in
+      Classes.existing_instance global qualid (Some {hint_priority; hint_pattern= None});
+      ereturn sigma (CoqUnit.mkTT)
 (* h is the mfix operator, a is an array of types of the arguments, b is the
    return type of the fixpoint, f is the function
    and x its arguments. *)

--- a/tests/declare.v
+++ b/tests/declare.v
@@ -239,3 +239,25 @@ Module M4.
 
 End M4.
 End Inductives.
+
+
+Module ExistingInstance.
+  Module Inner.
+    Class dummy := Dummy { dummy_nat : nat; dummy_extra : string }.
+
+    Definition test_global5 : dummy := Dummy 5 "5".
+    Definition test_global55 : dummy := Dummy 55 "55".
+    Definition test_local1 : dummy := Dummy 1 "1".
+
+    Mtac Do (M.existing_instance "test_global5" (mSome 5%N) true ).
+    Mtac Do (M.existing_instance "test_global55" (mSome 55%N) true ).
+    Mtac Do (M.existing_instance "test_local1" (mSome 1%N) false).
+
+    Mtac Do (M.ret (meq_refl : dummy_nat =m= 1)).
+  End Inner.
+
+  Fail Mtac Do (M.ret (meq_refl : Inner.dummy_nat =m= 1)).
+  Mtac Do (M.ret (meq_refl : Inner.dummy_nat =m= 5)).
+  Fail Mtac Do (M.ret (meq_refl : Inner.dummy_nat =m= 55)).
+
+End ExistingInstance.

--- a/theories/intf/M.v
+++ b/theories/intf/M.v
@@ -358,6 +358,9 @@ Definition declare_mind
   t unit.
   make. Qed.
 
+Definition existing_instance (name : string) (priority : moption N) (global : bool) : t unit.
+  make. Qed.
+
 Arguments t _%type.
 
 Definition fmap {A:Type} {B:Type} (f : A -> B) (x : t A) : t B :=


### PR DESCRIPTION
This adds a new primitive that mirrors the functionality of `Existing
Instance`. Interestingly, this seems to be all we need to support
declaring type class instances: together with `M.declare`,
`M.existing_instance` can be used to emulate Coq's `Instance`
vernacular.