### PR TITLE
Moving names of primitive atomic tactics from Coq.Init.Notations to Coq.Init.Ltac

### DIFF
--- a/tests/mctacticstests.v
+++ b/tests/mctacticstests.v
@@ -142,13 +142,13 @@ MProof.
   - exact G.
 Qed.
 
-Definition transitivity := "Coq.Init.Notations.transitivity".
+Definition transitivity := "Coq.Init.Ltac.transitivity".
 
 Lemma test6 : forall (x y z : Prop), x = y -> y = z -> x = z.
 MProof.
   intros x y z H G.
   ltac transitivity [m:Dyn y].
-  ltac "Coq.Init.Notations.revgoals" [m:].
+  ltac "Coq.Init.Ltac.revgoals" [m:].
   exact H.
   exact G.
 Qed.


### PR DESCRIPTION
There is a Coq PR coq/coq#12023 which introduces a specific file `Ltac.v` to activate the ltac plugin. This implies a change of qualification of the primitive atomic tactics from Coq.Init.Notations to Coq.Init.Ltac.

This PR adapts Mtac2 to the change.

Maybe a backward-compatible fix is possible but the proposed PR is not: I just adapted the code word by word. So, it should be merged only synchronously with coq/coq#12023.