### PR TITLE
Backport #266 to master-8.11

### DIFF
--- a/src/run.ml
+++ b/src/run.ml
@@ -1756,11 +1756,12 @@ let rec run' ctxt (vms : vm list) =
                           let rec traverse sigma t_args c_args =
                             match c_args with
                             | [] ->
+                                let t_args = List.map of_econstr t_args in
                                 (run'[@tailcall]) {ctxt with sigma = sigma; stack=Zapp (Array.of_list t_args) :: stack} (upd cont_success)
                             | c_h :: c_args ->
                                 match t_args with
                                 | t_h :: t_args ->
-                                    let (unires, _) = UnificationStrategy.unify None sigma env uni Reduction.CONV (to_econstr t_h) c_h in
+                                    let (unires, _) = UnificationStrategy.unify None sigma env uni Reduction.CONV t_h c_h in
                                     begin
                                       match unires with
                                       | Evarsolve.Success (sigma) -> traverse sigma t_args c_args
@@ -1772,7 +1773,7 @@ let rec run' ctxt (vms : vm list) =
                                     (* efail (E.mkWrongTerm sigma env c_head) *)
                                     fail ()
                           in
-                          traverse sigma (List.map of_econstr t_args) c_args
+                          traverse sigma t_args c_args
                         else
                           (* efail (E.mkWrongTerm sigma env c_head) *)
                           (run'[@tailcall]) ctxt (upd cont_failure)

--- a/src/run.ml
+++ b/src/run.ml
@@ -1747,6 +1747,67 @@ let rec run' ctxt (vms : vm list) =
                         (* : A B m uni a C cont  *)
                         let (t_head, t_args) = decompose_app sigma (to_econstr t) in
                         let (c_head, c_args) = decompose_app sigma (to_econstr c) in
+                        (* We need to be careful about primitive projections.
+                           In particular, we always need to unify parameters *if* the pattern contains them.
+                           There are several situations to consider that involve primitive projections:
+                           1. [c_head] is a primitive projection but [t_head] isn't
+                           2. [t_head] is a primitive projection but [c_head] isn't
+                           3. Both are primitive projections
+                        *)
+                        let (c_head, c_args), (t_head, t_args) =
+                          match (isProj sigma c_head, isProj sigma t_head) with
+                          | (false, false) ->     (* nothing to do *)
+                              (c_head, c_args), (t_head, t_args)
+                          | (true, false) ->
+                              (* In this case, the record value must be part of the left-hand side
+                                 of the pattern * i.e. [pattern = proj r | ...].
+                                 (Otherwise the pattern could not be a primitive projection.)
+                                 If we know that [t_head] is the folded version of [c_head] we
+                                 can simply unify the record values.
+                                 Otherwise it could be literally anything. In that case, we expand [c_head].
+                              *)
+                              let c_proj, c_rval = destProj sigma c_head in
+                              let c_constant = (Projection.constant c_proj) in
+                              if isConstant sigma c_constant t_head then
+                                let n_params = Recordops.find_projection_nparams (GlobRef.ConstRef c_constant) in
+                                let _t_params, t_args = List.chop n_params t_args in
+                                (t_head, c_rval :: c_args), (t_head, t_args)
+                              else
+                                let c = Retyping.expand_projection env sigma c_proj c_rval c_args in
+                                let c_head, c_args = decompose_app sigma c in
+                                (c_head, c_args), (t_head, t_args)
+                          | (false, true) ->
+                              (* Trying to be clever about this case, too.
+                                 There is a clever version of this case:
+                                 If [c_head] is the folded version of [t_head] and
+                                 [c_args] contains the record value (i.e. [pattern = folded_proj ... r | ])
+                                 we can avoid expanding [t] by dropping [n_params] arguments from [c_args].
+
+                                 However, this breaks the requirement that if the pattern mentions the parameters
+                                 we should unify them. Thus, we always expand in this case.
+                              *)
+                              let t_proj, t_rval = destProj sigma t_head in
+                              (* Code for clever verison:
+                               * let t_constant = (Projection.constant t_proj) in
+                               * let n_params = Recordops.find_projection_nparams (GlobRef.ConstRef t_constant) in
+                               * if isConstant sigma t_constant c_head && List.length c_args > n_params then
+                               *   let _c_params, c_args = List.chop n_params c_args in
+                               *   (\* we use [c_head] on both sides to make sure they are considered equal *\)
+                               *   (c_head, c_args), (c_head, t_args)
+                               * else *)
+                              let t = Retyping.expand_projection env sigma t_proj t_rval t_args in
+                              let t_head, t_args = decompose_app sigma t in
+                              (c_head, c_args), (t_head, t_args)
+                          | (true, true) ->
+                              let (c_proj, c_rval) = destProj sigma c_head in
+                              let (t_proj, t_rval) = destProj sigma t_head in
+                              if Projection.equal c_proj t_proj then
+                                (* we use [c_head] on both sides to make sure they are considered equal *)
+                                (c_head, c_rval :: c_args), (c_head, t_rval :: t_args)
+                              else
+                                (* no way to succeed anyway but we'll leave that to [eq_constr_nounivs] below *)
+                                (c_head, c_args), (t_head, t_args)
+                        in
                         if eq_constr_nounivs sigma t_head c_head then
                           let uni = to_econstr uni in
                           (* We need to capture the initial sigma here, as

--- a/tests/test_mmatch.v
+++ b/tests/test_mmatch.v
@@ -250,6 +250,69 @@ Mtac Do (
       end
      ).
 
+(* Non-primitive projections *)
+Record R1 := { f1 : nat }.
+Mtac Do (
+       mmatch f1 {| f1 := 1 |} with
+       | [#] f1 | r =u> M.unify_or_fail UniMatchNoRed (r) ({|f1 := 1|});; M.ret I
+      end
+     ).
+
+Set Primitive Projections.
+Record R2 := { f2 : nat }.
+Mtac Do (
+       mmatch f2 {| f2 := 1 |} with
+       | [#] f2 | r =u> M.unify_or_fail UniMatchNoRed (r) ({|f2 := 1|});; M.ret I
+      end
+     ).
+Mtac Do (
+       mmatch f2 {| f2 := 1 |} with
+       | [#] f2 {| f2 := 2 |} | =u> mfail "primitive projection error: record values were not unified at all"
+       | [#] f2 {| f2 := (0+1) |} | =n> mfail "primitive projection error: record values were unified but shouldn't have been"
+       | [#] f2 {| f2 := (0+1) |} | =u> M.ret I
+      end
+     ).
+Mtac Do (
+       mmatch {| f2 := 1 |}.(f2) with
+       | [#] @f2 {| f2 := 2 |} | =u> mfail "primitive projection error: record values were not unified at all"
+       | [#] @f2 {| f2 := (0+1) |} | =n> mfail "primitive projection error: record values were unified but shouldn't have been"
+       | [#] @f2 {| f2 := (0+1) |} | =u> M.ret I
+      end
+     ).
+
+(* Primitive records with parameters *)
+Record R3 {p : nat} := { f3 : bool }.
+(* Primitive target, non-primitive branches *)
+Definition R3_test1 :=
+       mmatch f3 (Build_R3 1 true) return M True with
+       | [#] @f3 2 | r =u> mfail "primitive projection error: record parameters should not match"
+       | [#] @f3 (0+1) | r =n> mfail "primitive projection error: record parameters were unified but shouldn't have been"
+       | [#] @f3 (0+1) | r =u> M.unify_or_fail UniMatchNoRed (r) (Build_R3 1 true);; M.ret I
+      end.
+Mtac Do (R3_test1).
+
+Definition R3_test2 :=
+       mmatch f3 (Build_R3 1 true) return M True with
+       | [#] f3 (Build_R3 1 true) | =n> M.ret I
+      end.
+Mtac Do (R3_test2).
+
+Definition R3_test3 :=
+  (* Only way to enter non-primitive projections for primitive records *)
+  ltac:(let p := constr:(@f3 (0+1)) in
+        exact(
+            (* Unfortunately, once the match is executed the projection is unfolded already. *)
+            mmatch p (Build_R3 1 true) return M True with
+            | [#] f3 (Build_R3 1 true) | =n> mfail "primitive projection error: record parameters were unified but shouldn't have been"
+            | [#] f3 (Build_R3 2 true) | =n> mfail "primitive projection error: record values were unified but shouldn't have been"
+            | [#] f3 (Build_R3 (0+1) true) | =n> M.ret I
+          end
+      )
+    ).
+(* There is nothing we can do about this with the way the compatability constants are unfolded automatically. *)
+Fail Mtac Do (R3_test3).
+
+
 (* [decompose_forall[P|T]] *)
 Mtac Do (
        mmatch (forall x : nat, x = x) with


### PR DESCRIPTION
The indentation change really makes it annoying to backport changes.

I ended up going with
```
git cherry-pick <commit> --strategy recursive -Xignore-space-change
```

And then manually indenting the code, making a new commit for that (to get the indentation checker to complain in case I mess up) and then rebasing/revising that into the cherry-picked commit.