### PR TITLE
[8.11] Cleaning up the pattern & branch types

### DIFF
--- a/examples/tauto.v
+++ b/examples/tauto.v
@@ -24,7 +24,7 @@ Module Mtac_V1.
   performance reasons. *)
   Fixpoint lookup (P : Prop) (l : list dyn) : M P :=
     match l with
-    | D :: l => mmatch D with | [? (p : P)] Dyn p =u> ret p | _ => lookup P l end
+    | D :: l => mmatch D with | [? (p : P)] Dyn p =u> ret p | _ as _catchall => lookup P l end
     |     [] => raise NotFound
     end.
 
@@ -32,6 +32,7 @@ Module Mtac_V1.
   list of hypothesis, and if it fails in tries to break it down into pieces and
   recurse over each part. *)
   Mtac Do New Exception TautoFail.
+  Arguments mcons _ & _ _.      (* TODO: figure out if we should have this everywhere *)
   Definition solve_tauto : forall (l : list dyn) {P : Prop}, M P :=
     mfix2 f (l : list dyn) (P : Prop) : M P :=
       mtry
@@ -61,7 +62,7 @@ Module Mtac_V1.
             raise TautoFail
           else
             ret (ex_intro Q x q)
-        | _ => raise TautoFail
+        | _ as _catchall => raise TautoFail
         end
       end.
 

--- a/tests/DepDestruct.v
+++ b/tests/DepDestruct.v
@@ -1,5 +1,5 @@
 From Mtac2
-Require Import Datatypes List Mtac2 DepDestruct Sorts.
+Require Import Datatypes List Mtac2 DepDestruct Sorts MTeleMatch.
 Import Sorts.S.
 Import T.
 Import Mtac2.lib.List.ListNotations.
@@ -150,15 +150,15 @@ Fixpoint unfold_funs {A} (t: A) (n: nat) {struct n} : M A :=
   match n with
   | 0 => M.ret t
   | S n' =>
-    mmatch A as A' return M A' with
-    | [? B (fty : B -> Type)] forall x, fty x => [H]
+    (mtmmatch A as A' return A =m= A' -> M A' with
+    | [? B (fty : B -> Type)] forall x, fty x =m> fun H =>
       let t' := reduce RedSimpl match H in meq _ P return P with meq_refl => t end in (* we need to reduce this *)
       M.nu (FreshFrom "A") mNone (fun x=>
         r <- unfold_funs (t' x) n';
         abs x r)
-    | [? A'] A' => [H]
+    | [? A'] A' =m> fun H =>
       match H in meq _ P return M P with meq_refl => M.ret t end
-    end
+    end) meq_refl
   end%MC.
 
 (* MetaCoq version *)

--- a/tests/Exhaustive.v
+++ b/tests/Exhaustive.v
@@ -5,20 +5,20 @@ Import M.notations.
 Check (mmatch 1 exhaustively_with
       | [#] S | n =n> M.print "S"
       | [#] O | =n> M.print "O"
-      | _ => M.print "not in constructor normal form"
+      | _ as _catchall => M.print "not in constructor normal form"
       end).
 
 (* Test a different order *)
 Check (mmatch 1 exhaustively_with
       | [#] O | =n> M.print "O"
       | [#] S | n =n> M.print "S"
-      | _ => M.print "not in constructor normal form"
+      | _ as _catchall => M.print "not in constructor normal form"
       end).
 
 (* Test another order. This one makes no sense but it is exhaustive in the sense
 of the checker. *)
 Check (mmatch 1 exhaustively_with
-      | _ => M.print "always triggered first"
+      | _ as _catchall => M.print "always triggered first"
       | [#] O | =n> M.print "O, never triggered"
       | [#] S | n =n> M.print "S, never triggered"
       end).
@@ -26,18 +26,18 @@ Check (mmatch 1 exhaustively_with
 (* Forget a constructor *)
 Fail Check (mmatch 1 exhaustively_with
       | [#] S | n =n> M.print "S"
-      | _ => M.print "not in constructor normal form"
+      | _ as _catchall => M.print "not in constructor normal form"
       end).
 
 (* Forget another constructor *)
 Fail Check (mmatch 1 exhaustively_with
       | [#] O | =n> M.print "O"
-      | _ => M.print "not in constructor normal form"
+      | _ as _catchall => M.print "not in constructor normal form"
       end).
 
 (* Forget constructor, swap order. *)
 Fail Check (mmatch 1 exhaustively_with
-      | _ => M.print "not in constructor normal form"
+      | _ as _catchall => M.print "not in constructor normal form"
       | [#] O | =n> M.print "O"
       end).
 
@@ -45,12 +45,12 @@ Fail Check (mmatch 1 exhaustively_with
 Check (mmatch cons 1 nil exhaustively_with
       | [#] @nil _ | =n> M.print "nil"
       | [#] @cons _ | a l =n> M.print "cons"
-      | _ => M.print "not in constructor normal form"
+      | _ as _catchall => M.print "not in constructor normal form"
       end).
 
 (* Check inductive type with parameters which we instantiate with syntactically different but convertible values. *)
 Check (mmatch cons 1 nil exhaustively_with
       | [#] @nil (id nat) | =n> M.print "nil"
       | [#] @cons nat | a l =n> M.print "cons"
-      | _ => M.print "not in constructor normal form"
+      | _ as _catchall => M.print "not in constructor normal form"
       end).

--- a/tests/abs.v
+++ b/tests/abs.v
@@ -6,7 +6,7 @@ Require Import Strings.String.
 Require Import Lists.List.
 Import ListNotations.
 
-Definition assert_eq {A} (a b : A) : M True := mmatch b with a => M.ret I | _ => M.raise exception end.
+Definition assert_eq {A} (a b : A) : M True := mmatch b with a => M.ret I | _ as _catchall => M.raise exception end.
 
 (* Abstracting an index works *)
 Goal True.

--- a/tests/abs_prod.v
+++ b/tests/abs_prod.v
@@ -4,7 +4,7 @@ Goal forall x:nat, True.
 MProof.
   intro x.
   (aP <- M.abs_prod_type x (x <= 0:Type);
-   mmatch aP with (forall y, y <= 0:Type) =c> M.ret _ | _ => M.failwith "Didn't work" end)%MC.
+   mmatch aP with (forall y, y <= 0:Type) =c> M.ret _ | _ as _catchall => M.failwith "Didn't work" end)%MC.
 Abort.
 
 Import M.

--- a/tests/bug_universes.v
+++ b/tests/bug_universes.v
@@ -32,9 +32,9 @@ Abort.
 Lemma testLApply@{i j} : Type@{i} -> Type@{max(i,j)}.
 Proof. apply @id. Qed.
 
-Notation "p '=e>' b" := (pbase p%core (fun _ => b%core) UniEvarconv)
+Notation "p '=e>' b" := (pbase p%core (b%core) UniEvarconv)
   (no associativity, at level 201) : pattern_scope.
-Notation "p '=e>' [ H ] b" := (pbase p%core (fun H => b%core) UniEvarconv)
+Notation "p '=e>' [ H ] b" := (pbase p%core (b%core) UniEvarconv)
   (no associativity, at level 201, H at next level) : pattern_scope.
 
 Definition test_match {A:Type(*k*)} (x:A) : tactic :=

--- a/tests/bugs.v
+++ b/tests/bugs.v
@@ -28,18 +28,19 @@ end.
 
 Definition fubarType :=
   Eval compute in
-  ltac:(mrun (mtry fubar Type (True <-> True) with _ => M.ret True end)%MC).
+  ltac:(mrun (mtry fubar Type (True <-> True) with _ as _catchall => M.ret True end)%MC).
 
+(* TODO: this test no longer works unless we want to import MTeleMatch here *)
 (** With mmatch should be the same *)
-Example fubar_mmatch (T : Type) (A : T) : M Prop:=
-  mmatch T with
-  | Prop => [eq] M.ret (meq_rect Prop (fun T=>T -> Prop) id T (meq_sym eq) A)
-  | _ => M.raise exception
-  end.
+(* Example fubar_mmatch (T : Type) (A : T) : M Prop:= *)
+(*   mmatch T with *)
+(*   | Prop => [H] M.ret (meq_rect Prop (fun T=>T -> Prop) id T (meq_sym H) A) *)
+(*   | _ as _catchall => M.raise exception *)
+(*   end. *)
 
-Definition fubarType_mmatch :=
-  Eval compute in
-  ltac:(mrun (mtry fubar_mmatch Type (True <-> True) with _ => M.ret True end)%MC).
+(* Definition fubarType_mmatch := *)
+(*   Eval compute in *)
+(*   ltac:(mrun (mtry fubar_mmatch Type (True <-> True) with _ as _catchall => M.ret True end)%MC). *)
 
 (** the bind overloaded notation was reducing terms using typeclasses. destcase expects a match, but it finds false *)
 Definition destcase_fail := ltac:(mrun (r <- M.ret (match 3 with 0 => true | _ => false end); _ <- M.destcase r; M.ret I)%MC).

--- a/tests/bugs/bug225.v
+++ b/tests/bugs/bug225.v
@@ -12,7 +12,7 @@ Definition reduce_nu :=
           (fun k =>
              mtry k with
              | StuckTerm => M.ret tt
-             | _ => M.failwith "expected StuckTerm"
+             | _ as _catchall => M.failwith "expected StuckTerm"
              end
           )
       )

--- a/tests/declare.v
+++ b/tests/declare.v
@@ -85,7 +85,7 @@ Fail Compute fun x y =>
           ltac:(mrun (
                     mtry
                       M.declare dok_Definition "lenS" true (Le.le_n_S x y);; M.ret tt
-                      with | UnboundVar => M.failwith "This must fail" | _ => M.ret tt end
+                      with | UnboundVar => M.failwith "This must fail" | _ as _catchall => M.ret tt end
                )).
 
 (* This used to fail because of weird universe issues. *)

--- a/tests/decompose.v
+++ b/tests/decompose.v
@@ -8,7 +8,7 @@ Definition decompose {T} (x : T) :=
     mmatch d with
     | [? A B (t1: A -> B) t2] Dyn (t1 t2) => f (Dyn t1) (Dyn t2 :m: args)
     | [? A B (t1: forall (x:A), B x) t2] Dyn (t1 t2) => f (Dyn t1) (Dyn t2 :m: args)
-    | _ => M.ret (m: d, args)
+    | _ as _catchall => M.ret (m: d, args)
     end) (Dyn x) [m:].
 
 (* If I'm not mistaken, the problem comes from the unification of
@@ -22,6 +22,6 @@ Goal True.
   MProof.
    Fail mmatch Dyn (@M.ret True) with
    | [? (P : Type -> Prop) (t1 : forall X:Type, P X) (t2 : Prop) ]  @Dyn (P t2) (t1 t2) => M.ret I
-    | _ => M.raise exception
+    | _ as _catchall => M.raise exception
   end.
 Abort.

--- a/tests/goal_reordering.v
+++ b/tests/goal_reordering.v
@@ -18,7 +18,7 @@ Definition ThrowANat (n : nat) : Exception. exact exception. Qed.
 Definition test n : M nat :=
   mmatch n with
   | [? n'] S n' => M.raise (ThrowANat n')
-  | _ => M.ret 0
+  | _ as _catchall => M.ret 0
   end.
 
 Goal True.

--- a/tests/reif_jason.v
+++ b/tests/reif_jason.v
@@ -536,7 +536,7 @@ Module Mtac2Mmatch.
             =n> M.ret (Some v)
           | [? x v xs] (var_context.cons x v xs)
             =n> find_in_ctx xs
-          | _ => M.ret None
+          | _ as _catchall => M.ret None
            end)) ctx.
 
    Definition reify_helper {var : Type} (term : nat) (ctx : @var_context.var_context var) : M (@expr var)
@@ -598,7 +598,7 @@ Module MTac2.
        | var_context.cons term' v xs =>
          mmatch term' with
          | [#] term | =n> M.ret (Some v)
-         | _ => M.ret None
+         | _ as _catchall => M.ret None
          end
        | _ => M.ret None
        end.

--- a/tests/test_mmatch.v
+++ b/tests/test_mmatch.v
@@ -61,7 +61,7 @@ Definition inlist A (x : A) : forall (l : list A), M (In x l) :=
       end)
   | [? s] (x :: s) => M.ret (in_eq _ _)
   | [? y s] (y :: s) => r <- f s; M.ret (in_cons y _ _ r)
-  | _ => M.raise NotFound
+  | _ as _catchall => M.raise NotFound
   end.
 Import ListNotations.
 
@@ -125,7 +125,7 @@ Definition inlist_nored A (x : A) : forall (l : list A), M (In x l) :=
       ir <- f r;
       M.ret (in_or_app l r x (or_intror ir))
     end
-  | _ => M.raise NotFound
+  | _ as _catchall => M.raise NotFound
   end.
 
 Example with_red : In 0 ([1;2]++[0;4]).
@@ -158,7 +158,7 @@ Definition inlist_redcons A (x : A) : forall (l : list A), M (In x l) :=
       ir <- f r;
       M.ret (in_or_app l r x (or_intror ir))
     end
-  | _ => M.raise NotFound
+  | _ as _catchall => M.raise NotFound
   end.
 
 Example with_redcons : In 0 ([1;2]++[0;4]).

--- a/tests/test_mtry.v
+++ b/tests/test_mtry.v
@@ -9,7 +9,7 @@ Qed.
 
 Goal True.
 MProof.
-  mtry raise exception with _ => ret I end.
+  mtry raise exception with _ as _catchall => ret I end.
 Qed.
 
 Definition one : Exception. exact exception. Qed.

--- a/tests/ttactics.v
+++ b/tests/ttactics.v
@@ -73,14 +73,14 @@ Module SelemOf.
         match_goal with | [[?P |- P]] =>
           mmatch P return M (P *m _) with
           | unit =n> TT.idtac : M _
-          | _ => mfail "[P] not forwarded as exactly [P] to [match_goal] branch"
+          | _ as _catchall => mfail "[P] not forwarded as exactly [P] to [match_goal] branch"
           end
         end)%MC%TT.
   Definition test_Prop := (
         match_goal with | [[?P : Prop |- P]] =>
           mmatch P return M (P *m _) with
           | True =n> TT.idtac : M _
-          | _ => mfail "[P] not forwarded as exactly [P] to [match_goal] branch"
+          | _ as _catchall => mfail "[P] not forwarded as exactly [P] to [match_goal] branch"
           end
         end)%MC%TT.
   Goal unit.

--- a/theories/Pattern.v
+++ b/theories/Pattern.v
@@ -9,31 +9,31 @@ Set Polymorphic Inductive Cumulativity.
 (** Pattern matching without pain *)
 (* The M will be instantiated with the M monad or the gtactic monad. In principle,
 we could make it part of the B, but then higher order unification will fail. *)
-Inductive pattern@{a} (A : Type@{a}) (B : A -> Prop) (y : A) : Prop :=
-  | pany : B y -> pattern A B y
-  | pbase : forall x : A, (y =m= x -> B x) -> Unification -> pattern A B y
-  | ptele : forall {C:Type@{a}}, (forall x : C, pattern A B y) -> pattern A B y
-  | psort : (Sort -> pattern A B y) -> pattern A B y.
+Inductive pattern@{a} (A : Type@{a}) (B : A -> Prop) : Prop :=
+  | pany : (forall x : A, B x) -> pattern A B
+  | pbase : forall x : A, B x -> Unification -> pattern A B
+  | ptele : forall {C:Type@{a}}, (forall x : C, pattern A B) -> pattern A B
+  | psort : (Sort -> pattern A B) -> pattern A B.
 
 
-Arguments pany {A B y} _.
-Arguments pbase {A B y} _ _ _.
-Arguments ptele {A B y C} _.
-Arguments psort {A B y} _.
+Arguments pany {A B} _.
+Arguments pbase {A B} _ _ _.
+Arguments ptele {A B C} _.
+Arguments psort {A B} _.
 
-Inductive branch : forall {A : Type} {B : A -> Prop} {y : A}, Prop :=
-| branch_pattern {A : Type} {B : A -> Prop} {y}: pattern A B y -> @branch A B y
-| branch_app_static {A : Type} {B : A -> Prop} {y}:
+Inductive branch : forall {A : Type} {B : A -> Prop}, Prop :=
+| branch_pattern {A : Type} {B : A -> Prop}: pattern A B -> @branch A B
+| branch_app_static {A : Type} {B : A -> Prop}:
     forall {m:MTele} (uni : Unification) (C : selem_of (MTele_Const (s:=Typeₛ) A m)),
       MTele_sort (MTele_ConstMap (si := Typeₛ) Propₛ (fun a : A => B a) C) ->
-      @branch A B y
-| branch_forallP {B : Prop -> Prop} {y}:
+      @branch A B
+| branch_forallP {B : Prop -> Prop}:
     (forall (X : Type) (Y : X -> Prop), B (forall x : X, Y x)) ->
-    @branch Prop B y
-| branch_forallT {B : Type -> Prop} {y : Type}:
+    @branch Prop B
+| branch_forallT {B : Type -> Prop}:
     (forall (X : Type) (Y : X -> Type), B (forall x : X, Y x)) ->
-    @branch Type B y.
-Arguments branch _ _ _ : clear implicits.
+    @branch Type B.
+Arguments branch _ _ : clear implicits.
 
 
 (* | branch_app_dynamic {A} {B : forall A, A -> Type} {y}: *)
@@ -41,6 +41,7 @@ Arguments branch _ _ _ : clear implicits.
 (*     @branch M _ B A y *)
 
 Declare Scope pattern_scope.
+Delimit Scope pattern_scope with pattern.
 
 Notation "[¿ s .. t ] ps" := (psort (fun s => .. (psort (fun t => ps)) ..))
   (at level 202, s binder, t binder, ps at next level, only parsing) : pattern_scope.
@@ -49,37 +50,40 @@ Notation "'[S?' s .. t ] ps" := (psort (fun s => .. (psort (fun t => ps)) ..))
 
 Notation "[? x .. y ] ps" := (ptele (fun x => .. (ptele (fun y => ps)).. ))
   (at level 202, x binder, y binder, ps at next level) : pattern_scope.
-Notation "p => b" := (pbase p%core (fun _ => b%core) UniMatch)
+Notation "p => b" := (pbase p%core b%core UniMatch)
   (no associativity, at level 201) : pattern_scope.
-Notation "p => [ H ] b" := (pbase p%core (fun H => b%core) UniMatch)
-  (no associativity, at level 201, H at next level) : pattern_scope.
-Notation "p => [ H .. G ] b" := (pbase p%core (fun H => .. (fun G => b%core) .. ) UniMatch)
-  (no associativity, at level 201, H binder, G binder) : pattern_scope.
-Notation "'_' => b " := (pany b%core)
-  (at level 201, b at next level) : pattern_scope.
+(* Notation "p => [ H ] b" := (pbase p%core (fun H => b%core) UniMatch) *)
+(*   (no associativity, at level 201, H at next level) : pattern_scope. *)
+(* Notation "p => [ H .. G ] b" := (pbase p%core (fun H => .. (fun G => b%core) .. ) UniMatch) *)
+  (* (no associativity, at level 201, H binder, G binder) : pattern_scope. *)
 
-Notation "p '=n>' b" := (pbase p%core (fun _ => b%core) UniMatchNoRed)
+Notation "p '=n>' b" := (pbase p%core b%core UniMatchNoRed)
   (no associativity, at level 201) : pattern_scope.
-Notation "p '=n>' [ H ] b" := (pbase p%core (fun H => b%core) UniMatchNoRed)
-  (no associativity, at level 201, H at next level) : pattern_scope.
-Notation "p =n> [ H .. G ] b" := (pbase p%core (fun H => .. (fun G => b%core) .. ) UniMatchNoRed)
-  (no associativity, at level 201, H binder, G binder) : pattern_scope.
+(* Notation "p '=n>' [ H ] b" := (pbase p%core b%core UniMatchNoRed) *)
+(*   (no associativity, at level 201, H at next level) : pattern_scope. *)
+(* Notation "p =n> [ H .. G ] b" := (pbase p%core (fun H => .. (fun G => b%core) .. ) UniMatchNoRed) *)
+(*   (no associativity, at level 201, H binder, G binder) : pattern_scope. *)
 
-Notation "p '=u>' b" := (pbase p%core (fun _ => b%core) UniCoq)
+Notation "p '=u>' b" := (pbase p%core b%core UniCoq)
   (no associativity, at level 201) : pattern_scope.
-Notation "p '=u>' [ H ] b" := (pbase p%core (fun H => b%core) UniCoq)
-  (no associativity, at level 201, H at next level) : pattern_scope.
-Notation "p =u> [ H .. G ] b" := (pbase p%core (fun H => .. (fun G => b%core) .. ) UniCoq)
-  (no associativity, at level 201, H binder, G binder) : pattern_scope.
+(* Notation "p '=u>' [ H ] b" := (pbase p%core (fun H => b%core) UniCoq) *)
+(*   (no associativity, at level 201, H at next level) : pattern_scope. *)
+(* Notation "p =u> [ H .. G ] b" := (pbase p%core (fun H => .. (fun G => b%core) .. ) UniCoq) *)
+(*   (no associativity, at level 201, H binder, G binder) : pattern_scope. *)
 
-Notation "p '=c>' b" := (pbase p%core (fun _ => b%core) UniEvarconv)
+Notation "p '=c>' b" := (pbase p%core b%core UniEvarconv)
   (no associativity, at level 201) : pattern_scope.
-Notation "p '=c>' [ H ] b" := (pbase p%core (fun H => b%core) UniEvarconv)
-  (no associativity, at level 201, H at next level) : pattern_scope.
-Notation "p =c> [ H .. G ] b" := (pbase p%core (fun H => .. (fun G => b%core) .. ) UniEvarconv)
-  (no associativity, at level 201, H binder, G binder) : pattern_scope.
+(* Notation "p '=c>' [ H ] b" := (pbase p%core (fun H => b%core) UniEvarconv) *)
+(*   (no associativity, at level 201, H at next level) : pattern_scope. *)
+(* Notation "p =c> [ H .. G ] b" := (pbase p%core (fun H => .. (fun G => b%core) .. ) UniEvarconv) *)
+(*   (no associativity, at level 201, H binder, G binder) : pattern_scope. *)
 
 Delimit Scope pattern_scope with pattern.
+
+Notation "'_' 'as' _catchall => b " := (pany (fun _catchall => b%core))
+  (at level 201, b at next level) : pattern_scope.
+
+
 
 Declare Scope branch_scope.
 
@@ -90,45 +94,42 @@ Notation "'[S?' s .. t ] ps" := (branch_pattern (psort (fun s => .. (psort (fun 
 
 Notation "[? x .. y ] ps" := (branch_pattern (ptele (fun x => .. (ptele (fun y => ps%pattern)).. )))
   (at level 202, x binder, y binder, ps at next level) : branch_scope.
-Notation "p => b" := (branch_pattern (pbase p%core (fun _ => b%core) UniMatch))
+Notation "p => b" := (branch_pattern (pbase p%core b%core UniMatch))
   (no associativity, at level 201) : branch_scope.
-Notation "p => [ H ] b" := (branch_pattern (pbase p%core (fun H => b%core) UniMatch))
-  (no associativity, at level 201, H at next level) : branch_scope.
-Notation "p => [ H .. G ] b" := (branch_pattern (pbase p%core (fun H => .. (fun G => b%core) .. ) UniMatch))
-  (no associativity, at level 201, H binder, G binder) : branch_scope.
-Notation "'_' => b " := (branch_pattern (pany b%core))
-  (at level 201, b at next level) : branch_scope.
+(* Notation "p => [ H ] b" := (branch_pattern (pbase p%core (fun H => b%core) UniMatch)) *)
+(*   (no associativity, at level 201, H at next level) : branch_scope. *)
+(* Notation "p => [ H .. G ] b" := (branch_pattern (pbase p%core (fun H => .. (fun G => b%core) .. ) UniMatch)) *)
+(*   (no associativity, at level 201, H binder, G binder) : branch_scope. *)
 
-Notation "p '=n>' b" := (branch_pattern (pbase p%core (fun _ => b%core) UniMatchNoRed))
+Notation "p '=n>' b" := (branch_pattern (pbase p%core b%core UniMatchNoRed))
   (no associativity, at level 201) : branch_scope.
-Notation "p '=n>' [ H ] b" := (branch_pattern (pbase p%core (fun H => b%core) UniMatchNoRed))
-  (no associativity, at level 201, H at next level) : branch_scope.
-Notation "p =n> [ H .. G ] b" := (branch_pattern (pbase p%core (fun H => .. (fun G => b%core) .. ) UniMatchNoRed))
-  (no associativity, at level 201, H binder, G binder) : branch_scope.
+(* Notation "p '=n>' [ H ] b" := (branch_pattern (pbase p%core (fun H => b%core) UniMatchNoRed)) *)
+(*   (no associativity, at level 201, H at next level) : branch_scope. *)
+(* Notation "p =n> [ H .. G ] b" := (branch_pattern (pbase p%core (fun H => .. (fun G => b%core) .. ) UniMatchNoRed)) *)
+(*   (no associativity, at level 201, H binder, G binder) : branch_scope. *)
 
-Notation "p '=u>' b" := (branch_pattern (pbase p%core (fun _ => b%core) UniCoq))
+Notation "p '=u>' b" := (branch_pattern (pbase p%core b%core UniCoq))
   (no associativity, at level 201) : branch_scope.
-Notation "p '=u>' [ H ] b" := (branch_pattern (pbase p%core (fun H => b%core) UniCoq))
-  (no associativity, at level 201, H at next level) : branch_scope.
-Notation "p =u> [ H .. G ] b" := (branch_pattern (pbase p%core (fun H => .. (fun G => b%core) .. ) UniCoq))
-  (no associativity, at level 201, H binder, G binder) : branch_scope.
+(* Notation "p '=u>' [ H ] b" := (branch_pattern (pbase p%core (fun H => b%core) UniCoq)) *)
+(*   (no associativity, at level 201, H at next level) : branch_scope. *)
+(* Notation "p =u> [ H .. G ] b" := (branch_pattern (pbase p%core (fun H => .. (fun G => b%core) .. ) UniCoq)) *)
+(*   (no associativity, at level 201, H binder, G binder) : branch_scope. *)
 
-Notation "p '=c>' b" := (branch_pattern (pbase p%core (fun _ => b%core) UniEvarconv))
+Notation "p '=c>' b" := (branch_pattern (pbase p%core b%core UniEvarconv))
   (no associativity, at level 201) : branch_scope.
-Notation "p '=c>' [ H ] b" := (branch_pattern (pbase p%core (fun H => b%core) UniEvarconv))
-  (no associativity, at level 201, H at next level) : branch_scope.
-Notation "p =c> [ H .. G ] b" := (branch_pattern (pbase p%core (fun H => .. (fun G => b%core) .. ) UniEvarconv))
-  (no associativity, at level 201, H binder, G binder) : branch_scope.
 
 Delimit Scope branch_scope with branch.
+
+Notation "'_' 'as' _catchall => b " := (branch_pattern (pany (fun _catchall => b%core)))
+  (at level 201, b at next level) : branch_scope.
 
 Declare Scope with_pattern_scope.
 
 Notation "'with' | p1 | .. | pn 'end'" :=
-  ((@mcons (branch _ _ _) p1%branch (.. (@mcons (branch _ _ _) pn%branch [m:]) ..)))
+  ((@mcons (branch _ _) p1%branch (.. (@mcons (branch _ _) pn%branch [m:]) ..)))
   (at level 91, p1 at level 210, pn at level 210) : with_pattern_scope.
 Notation "'with' p1 | .. | pn 'end'" :=
-  ((@mcons (branch _ _ _) p1%branch (.. (@mcons (branch _ _ _) pn%branch [m:]) ..)))
+  ((@mcons (branch _ _) p1%branch (.. (@mcons (branch _ _) pn%branch [m:]) ..)))
   (at level 91, p1 at level 210, pn at level 210) : with_pattern_scope.
 
 Delimit Scope with_pattern_scope with with_pattern.
@@ -204,40 +205,40 @@ Structure Predicate :=
     predicate_pred : Prop
   }.
 
-Structure Matcher {A : Type} {y : A} :=
+Structure Matcher {A} :=
   MATCHER {
     matcher_pred: forall y, Predicate;
     matcher_ret: Prop;
-    _ : forall (E: Exception) (ps : mlist (branch A (fun y => predicate_pred (matcher_pred y)) y)), matcher_ret
+    _ : forall (E: Exception) (ps : mlist (branch A (fun y => predicate_pred (matcher_pred y)))), matcher_ret
   }.
-Arguments Matcher {_} _.
-Arguments MATCHER {_} {_}.
+Arguments Matcher {_}.
+Arguments MATCHER {_}.
 
-Definition matcher_match {A y} (m : Matcher y) : forall (E: Exception) (ps : mlist (branch A (fun y => predicate_pred (matcher_pred m y)) y)), matcher_ret m :=
+Definition matcher_match {A} (m : Matcher) : forall (E: Exception) (ps : mlist (branch A (fun y => predicate_pred (matcher_pred m y)))), matcher_ret m :=
   ltac:(destruct m as [ ? ? x]; refine x).
 
 Structure InDepMatcher :=
   INDEPMATCHER {
     idmatcher_return : Prop;
-    _ : forall A y (E: Exception) (ps : mlist (branch A (fun _ => idmatcher_return) y)), idmatcher_return;
+    _ : forall A (y : A) (E: Exception) (ps : mlist (branch A (fun _ => idmatcher_return))), idmatcher_return;
   }.
 
-Definition idmatcher_match (m : InDepMatcher) : forall A y (E: Exception) (ps : mlist (branch A (fun _ => idmatcher_return m) y)), idmatcher_return m :=
+Definition idmatcher_match (m : InDepMatcher) : forall A y (E: Exception) (ps : mlist (branch A (fun _ => idmatcher_return m))), idmatcher_return m :=
   ltac:(destruct m as [ ? x]; refine x).
 
 Definition idmatcher_match_invert (m : InDepMatcher) (A : Type) (y : A) (R : Prop) :
   R =m= idmatcher_return m ->
-  forall (_ : Exception) (_ : mlist (branch A (fun _ => R) y)),
+  forall (_ : Exception) (_ : mlist (branch A (fun _ => R))),
     (* R y =m= matcher_return y m -> *)
     R.
   intros ->. eauto using idmatcher_match. Defined.
 
-Arguments idmatcher_match _ _ _ _ & _.
+Arguments idmatcher_match _ _ _ & _.
 
-Definition matcher_match_invert (A : Type) (y : A) (m : Matcher y) (R : A -> Prop) :
+Definition matcher_match_invert (A : Type) (y : A) (m : Matcher) (R : A -> Prop) :
   (matcher_ret m =m= R y) ->
   (fun y => predicate_pred (matcher_pred m y)) =m= R ->
-  forall (_ : Exception) (_ : mlist (branch A R y)),
+  forall (_ : Exception) (_ : mlist (branch A R)),
     (* R y =m= matcher_return y m -> *)
     R y.
   intros <- <-. eauto using matcher_match. Defined.

--- a/theories/ideas/Abstract.v
+++ b/theories/ideas/Abstract.v
@@ -130,7 +130,7 @@ Definition abstract A B (x : A) (t : B) : M (moption _) :=
          | mNone,    mSome Q' => ret (mSome (non_dep_eq (R (fun _ => P) meq_refl) Q'))
          | mNone,    mNone    => ret mNone
          end
-       | _ =n>
+       | _ as r =>
           let r' := dreduce (typer) (typer r) in
           mmatch r as r' return M (moption (result x (elemr r'))) with
           | [? A' (t1 : A' -> r') t2] Dynr (t1 t2)  =n>

--- a/theories/ideas/DepDestruct.v
+++ b/theories/ideas/DepDestruct.v
@@ -214,7 +214,7 @@ Program Fixpoint args_of_max (max : nat) : dyn -> M (mlist dyn) :=
       | [? T Q (t : T) (f : T -> Q)] Dyn (f t) =>
          r <- args_of_max max (Dyn f);
          M.ret (Dyn t :m: r)
-      | _ =>
+      | _ as _catchall =>
         T <- M.evar Type;
         P <- M.evar (T -> Type);
         f <- M.evar (forall x:T, P x);

--- a/theories/ideas/StaticApply.v
+++ b/theories/ideas/StaticApply.v
@@ -97,7 +97,7 @@ Definition apply_type_of (P : Type) :
          end
        else M.remove x_nu (M.ret r)
        )
-  | _ => fun _ =>
+  | _ as _catchall => fun _ =>
       M.failwith "The lemma's conclusion does not unify with the goal."
   end
 .

--- a/theories/ideas/SubgoalsStrict.v
+++ b/theories/ideas/SubgoalsStrict.v
@@ -63,7 +63,7 @@ Definition max_apply {T} (c : T) : tactic := fun g=>
           r <- go (Dyn (f e));
           M.ret r
         | Dyn eg =u> M.ret [m:]
-        | _ =>
+        | _ as _catchall =>
           dcase d as ty, el in
           M.raise (T.CantApply ty gT)
         end) (Dyn c)
@@ -78,7 +78,7 @@ Definition count_nondep_binders (T: Type) : M nat :=
       M.ret (S r)
     | [? T1 T2] (forall x:T1, T2 x) =>
       nu (FreshFromStr "name") mNone (fun e:T1=>go (T2 e))
-    | _ => M.ret 0
+    | _ as _catchall => M.ret 0
     end) T.
 
 Definition napply {T} {e: runner (count_nondep_binders T)} (c : T) : ntactic unit (@eval _ _ e) := fun g=>

--- a/theories/meta/Exhaustive.v
+++ b/theories/meta/Exhaustive.v
@@ -27,15 +27,15 @@ Definition find_in_constrs {C} (c : C)  : mlist dyn -> M (mlist dyn) :=
       let C := reduce (RedVmCompute) C in
       mmatch c' with
       | @Dyn C c =n> M.ret cs
-      | _ => l <- f cs; M.ret (c' :m: l)
+      | _ as _catchall => l <- f cs; M.ret (c' :m: l)
       end
     end.
 
 
-Definition check_exhaustiveness {A B y}
-           (ps_in : mlist (branch A B y))
-           (ops : moption (mlist (branch A B y))) :
-  M (mlist (branch A B y)) :=
+Definition check_exhaustiveness {A B}
+           (ps_in : mlist (branch A B))
+           (ops : moption (mlist (branch A B))) :
+  M (mlist (branch A B)) :=
   '(mkInd_dyn _ _ _ constrs) <- M.constrs A;
   (
     mfix2 f (ps : _) (constrs : _) : M _ :=

--- a/theories/meta/MFix.v
+++ b/theories/meta/MFix.v
@@ -11,12 +11,12 @@ Local Definition MFA {n} (T : MTele_Ty n) := (MTele_val (MTele_C Typeₛ Propₛ
 (* Less specific version of MTele_of in MTeleMatch.v *)
 Definition MTele_of' :=
   (mfix1 f (T : Prop) : M { m : MTele & { mT : MTele_Ty m & T =m= MFA mT } } :=
-     mmatch T as T0 return M { m : MTele & { mT : MTele_Ty m & T =m= MFA mT } } with
-     | [?X : Type] M X =u> [H]
+     (mtmmatch T as T0 return T =m= T0 -> M { m : MTele & { mT : MTele_Ty m & T =m= MFA mT } } with
+     | [?X : Type] M X =u> fun H =>
                         M.ret (existT (fun m => {mT : MTele_Ty m & T =m= MFA mT}) (mBase)
                                       (existT (fun mT : MTele_Ty mBase => T =m= MFA mT) _ H)
                               )
-     | [?(X : Type) (F : forall x:X, Prop)] (forall x:X, F x) =c> [H]
+     | [?(X : Type) (F : forall x:X, Prop)] (forall x:X, F x) =c> fun H =>
        M.nu (FreshFrom F) mNone (fun x =>
                        '(existT _ m (existT _ mT E)) <- f (F x);
                        m' <- M.abs_fun x m;
@@ -33,7 +33,7 @@ Definition MTele_of' :=
                        (* M.unify e er UniEvarconv;; *)
                        (* M.ret (existT (fun m => (forall x:X, F x) =m= MFA m) (mTele g) e) *)
                     )
-   end
+   end) meq_refl
   ).
 
 Definition MTele_of : Prop -> M (sigT MTele_Ty) :=

--- a/theories/meta/MTeleMatch.v
+++ b/theories/meta/MTeleMatch.v
@@ -132,6 +132,10 @@ Definition mtpbase_eq {A} {m : A -> Prop} (x : A) F (eq : m x =m= F x) : F x -> 
   | meq_refl => mtpbase x
   end.
 
+Definition mtpany_eq {A} {m : A -> Prop} F (eq : m =m= F) : (forall x, F x) -> mtpattern A m :=
+  match eq in _ =m= R return (forall x, R x) -> _ with
+  | meq_refl => fun f => mtpany f
+  end.
 
 Declare Scope mtpattern_scope.
 Bind Scope mtpattern_scope with mtpattern.
@@ -162,8 +166,8 @@ Notation "d '=n>' t" := (mtpbase_eq (m:=mty_of) d ret_ty cs_unify t UniMatchNoRe
 Notation "d '=m>' t" := (mtpbase_eq (m:=mty_of) d ret_ty cs_unify t UniMatch)
     (at level 201) : mtpattern_scope.
 
-Notation "'_' => b " := (mtptele (M:=mty_of) (fun x=> mtpbase_eq (m:=mty_of) x ret_ty cs_unify b%core UniMatch))
-  (at level 201, b at next level) : mtpattern_scope.
+Notation "'_' 'as' _catchall => b " := (mtpany_eq (m:=mty_of) ret_ty cs_unify (fun _catchall => b%core))
+  (at level 201) : mtpattern_scope.
 
 
 Declare Scope with_mtpattern_scope.
@@ -183,3 +187,9 @@ Notation "'mtmmatch' x 'as' y 'return' T p" :=
     let mt : MTY_OF := MTt_Of (fun _z => MTele_ty M (n:=mprojT1 (mt1 _z)) (mprojT2 (mt1 _z))) in
     mtmmatch' _ (fun y => mprojT1 (mt1 y)) (fun y => mprojT2 (mt1 y)) x p%with_mtpattern
   ) (at level 90, p at level 91).
+
+Local Example test_mtmmatch (n : nat) :=
+  mtmmatch n as n' return n = n' -> M (n = 1) with
+  | 1 =n> fun H => M.ret H
+  | _ as _catchall => fun H : n = _catchall => M.failwith "test"
+  end.

--- a/theories/meta/MTeleMatchDef.v
+++ b/theories/meta/MTeleMatchDef.v
@@ -9,11 +9,13 @@ Unset Universe Minimization ToSet.
 
 
 Inductive mtpattern A (M : A -> Prop)  : Prop :=
+| mtpany : (forall x : A, M x) -> mtpattern A M
 | mtpbase : forall x : A, M x -> Unification -> mtpattern A M
 | mtptele : forall {C}, (forall x : C, mtpattern A M) -> mtpattern A M
 | mtpsort : (Sort -> mtpattern A M) -> mtpattern A M.
 
 
+Arguments mtpany {A M} _.
 Arguments mtpbase {A M} _ _.
 Arguments mtptele {A M C} _.
 Arguments mtpsort {A M} _.
@@ -24,6 +26,7 @@ Local Notation MFA T := (MTele_val (MTele_C Typeₛ Propₛ M T)).
 Fixpoint open_branch {A} {m} {T : forall x, MTele_Ty (m x)} {y : A} {a : ArgsOf (m y)}
          (p : mtpattern A (fun x => MFA (T x))) : M (apply_sort (T y) a) :=
   match p return M _ with
+  | mtpany f => apply_C Propₛ (f y) a
   | mtpbase x f u =>
     oeq <- M.unify x y u;
     match oeq return M (apply_sort (T y) a) with

--- a/theories/tactics/ConstrSelector.v
+++ b/theories/tactics/ConstrSelector.v
@@ -29,7 +29,7 @@ Definition get_constrs :=
       M.nu (FreshFrom T) mNone (fun x=>
         fill (P x)
       )
-    | _ =>
+    | _ as _catchall =>
       '(mkInd_dyn _ _ _ l) <- M.constrs T;
       M.ret l
     end%MC.

--- a/theories/tactics/Tactics.v
+++ b/theories/tactics/Tactics.v
@@ -146,7 +146,7 @@ Definition generalize {A} (x : A) : tactic := fun g =>
         let e' := reduce (RedWhd [rl:RedMatch]) match H in _ =m= Q return Q with meq_refl _ => e end in
         exact (e' x) g;;
         M.ret [m:(m: tt, AnyMetavar Typeₛ _ e)]
-     | aP =n> fun _ => M.failwith "generalize"
+     | _ as _catchall => fun _ => M.failwith "generalize"
      end) meq_refl
   | Metavar Propₛ P _ =>
      aP <- M.abs_prod_prop x P; (* aP = (forall x:A, P) *)
@@ -156,7 +156,7 @@ Definition generalize {A} (x : A) : tactic := fun g =>
         let e' := reduce (RedWhd [rl:RedMatch]) match H in _ =m= Q return Q with meq_refl _ => e end in
         exact (e' x) g;;
         M.ret [m:(m: tt, AnyMetavar Propₛ _ e)]
-     | aP =n> fun H => M.failwith "generalize"
+     | _ as _catchall => fun H => M.failwith "generalize"
      end) meq_refl
   end.
 

--- a/theories/tactics/TacticsBase.v
+++ b/theories/tactics/TacticsBase.v
@@ -74,34 +74,34 @@ Definition fix4 {A1} {A2 : A1 -> Type} {A3 : forall a1 : A1, A2 a1 -> Type}
   @M.fix5 A1 A2 A3 A4 (fun _ _ _ _ => (goal _)) (fun x y z z' _ => mlist (B x y z z' *m (goal _))).
 
 
-Local Notation Tpattern A P y := (pattern A (fun y => gtactic (P y)) y).
-Local Notation Tbranch A P y := (branch A (fun y => gtactic (P y)) y).
+Local Notation Tpattern A P := (pattern A (fun y => gtactic (P y))).
+Local Notation Tbranch A P := (branch A (fun y => gtactic (P y))).
 
-Fixpoint pattern_map {A} {B : A -> Type} (g : (goal _)) (y : A)
-    (p : Tpattern A B y) : pattern A (fun y => M (mlist (B y *m (goal _)))) y :=
+Fixpoint pattern_map {A} {B : A -> Type} (g : (goal _))
+    (p : Tpattern A B) : pattern A (fun y => M (mlist (B y *m (goal _)))) :=
   match p with
-  | pany b => pany (b g)
-  | pbase x f r => pbase x (fun Heq => f Heq g) r
-  | ptele f => ptele (fun x => pattern_map g y (f x))
-  | psort f => psort (fun s => pattern_map g y (f s))
+  | pany f => pany (fun x => f x g)
+  | pbase x f r => pbase x (f g) r
+  | ptele f => ptele (fun x => pattern_map g (f x))
+  | psort f => psort (fun s => pattern_map g (f s))
   end.
 
-Definition branch_map {A} {B} (y : A) (g : (goal _)) (b : branch A (fun a => gtactic (B a)) y) :
-  branch A (fun y => M (mlist (B y *m (goal _)))) y :=
-  match b in branch A' P' y' return
+Definition branch_map {A} {B} (y : A) (g : (goal _)) (b : branch A (fun a => gtactic (B a))) :
+  branch A (fun y => M (mlist (B y *m (goal _)))) :=
+  match b in branch A' P' return
         forall B : A' -> Type,
         forall P_eq : P' =m= fun a => gtactic (B a),
-        branch A' (fun y => M (mlist (B y *m (goal _)))) y'
+        branch A' (fun y => M (mlist (B y *m (goal _))))
   with
-  | @branch_pattern _ _ y p =>
+  | @branch_pattern _ _ p =>
     fun B P_eq =>
-      let op p := branch_pattern (pattern_map g y p) in
+      let op p := branch_pattern (pattern_map g p) in
       ltac:(rewrite P_eq in p; refine (op p))
   | branch_app_static U ct cont =>
     fun _ P_eq =>
       let cont := ltac:(rewrite P_eq in cont; refine cont) in
       let cont := MTele.MTele_constmap_app (si:=Typeₛ) Propₛ (fun _ _ => _) ct cont g in
-      @branch_app_static _ _ _ _ U _ cont
+      @branch_app_static _ _ _ U _ cont
   | branch_forallP cont =>
     fun _ P_eq =>
       let cont := ltac:(rewrite P_eq in cont; refine cont) in
@@ -113,10 +113,10 @@ Definition branch_map {A} {B} (y : A) (g : (goal _)) (b : branch A (fun a => gta
   end B meq_refl.
 
 Definition mmatch' {A P} (E : Exception) (y : A)
-    (ps : mlist (Tbranch A P y)) : gtactic (P y) := fun g =>
-  M.mmatch' E y (mmap (branch_map y g) ps).
+    (ps : mlist (Tbranch A P)) : gtactic (P y) := fun g =>
+  M.mmatch' E (mmap (branch_map y g) ps) y.
 
-Definition mmatch'' {A:Type} {P: A -> Type} (E : Exception) (y : A) (failure : gtactic (P y)) (ps : mlist (Tbranch A P y)) : gtactic (P y) := fun g =>
+Definition mmatch'' {A:Type} {P: A -> Type} (E : Exception) (y : A) (failure : gtactic (P y)) (ps : mlist (Tbranch A P)) : gtactic (P y) := fun g =>
   M.mmatch'' E y (failure g) (mmap (branch_map y g) ps).
 
 Module Matcher.
@@ -138,10 +138,10 @@ Definition ret {A} (x : A) : gtactic A := fun '(Metavar _ _ g) => M.ret [m:(m: x
 Definition idtac : tactic := ret tt.
 
 Definition try (t : tactic) : tactic := fun '(Metavar _ _ g' as g)=>
-  mtry t g with _ => M.ret [m:(m: tt, AnyMetavar _ _ g')] end.
+  mtry t g with _ as _catchall => M.ret [m:(m: tt, AnyMetavar _ _ g')] end.
 
 Definition or {A} (t u : gtactic A) : gtactic A := fun g=>
-  mtry t g with _ => u g end.
+  mtry t g with _ as _catchall => u g end.
 
 Definition get_binder_name {A} (x : A) : gtactic string := fun '(Metavar _ _ g) =>
   s <- M.get_binder_name x; M.ret [m:(m: s,AnyMetavar _ _ g)].
@@ -190,7 +190,7 @@ Definition abstract_from_term_dep {A} {B} (x:A) (y:B) (D : B -> Type)
       M.raise (@Backtrack A B y f) (* nasty HACK: we backtract so as not to get evars
       floating: we only care about the term! (which should be well typed in the
       right sigma) *)
-    | _ => M.print_term gs;; M.failwith "abstract_from_sort: mmatch goal not ground"
+    | _ as _catchall => M.print_term gs;; M.failwith "abstract_from_sort: mmatch goal not ground"
     end
   with
   | [#] @Backtrack A B x | f =u>

--- a/theories/tactics/Ttactics.v
+++ b/theories/tactics/Ttactics.v
@@ -108,7 +108,7 @@ Definition apply_ {A} : ttac A :=
   by' apply_.
 
 Definition try {A} (t : ttac A) : ttac A :=
-  mtry t with _ => demote : M _ end.
+  mtry t with _ as _catchall => demote : M _ end.
 
 Mtac Do New Exception TTchange_Exception.
 Definition change A {B} (f : ttac A) : ttac B :=
@@ -174,7 +174,7 @@ Definition tassumption {A:Type} : ttac A :=
   lift (M.select _).
 
 Definition tor {A:Type} (t u : ttac A) : ttac A :=
-  mtry r <- t; M.ret r with _ => r <- u; M.ret r end.
+  mtry r <- t; M.ret r with _ as _catchall => r <- u; M.ret r end.
 
 Definition reflexivity {P} {A B : P} : TT.ttac (A = B) :=
   r <- M.coerce (eq_refl A); M.ret (m: r, [m:]).
@@ -223,7 +223,7 @@ Definition with_goal_prop (F : forall (P : Prop), ttac P) : tactic := fun g =>
       '(m: x, gs) <- F gP;
       M.cumul_or_fail UniCoq x g;;
       M.map (fun g => M.ret (m:tt,g)) gs
-    with _ => raise CantCoerce end (* its better to raise CantCoerce than NotCumul *)
+    with _ as _catchall => raise CantCoerce end (* its better to raise CantCoerce than NotCumul *)
   end.
 
 (** with_goal_type is an easy way of focusing on the current goal to go from
@@ -242,7 +242,7 @@ Definition with_goal_type (F : forall (T : Type), ttac T) : tactic := fun g =>
       '(m: x, gs) <- F G;
       M.cumul_or_fail UniCoq x g;;
       M.map (fun g => M.ret (m:tt,g)) gs
-    with _ => raise CantCoerce end (* its better to raise CantCoerce than NotCumul *)
+    with _ as _catchall => raise CantCoerce end (* its better to raise CantCoerce than NotCumul *)
   end.
 
 


### PR DESCRIPTION
This is a clean-up that I wanted to get done for a looong time. Working with our pattern types has always been a pain but I didn't see how to make it any easier without removing the default `_ => ..` pattern. It turns out that we can change it slightly without a lot of fallout (except for syntactic changes).

This PR is an attempt at making it easier to eventually solve #282 by unifying more of the pattern matching infrastructure.

The PR is against master-8.11 because I happened to be working on that branch but once it's done and accepted I'll port it to master as well.

TODO:

- [ ] bikeshed the catch-all pattern syntax. Right now it's `_ as binder => ..` but that's very ugly. I don't think we can or should make it just `binder => ..` because that's confusing and probably illegal syntax. We could go with `[otherwise] binder => ..` or `[else] binder => ..`? We aren't using `[!]` in patterns but it doesn't exactly scream "default case". I am open to further suggestions.

### 1. Commit:

Clean up mmatch, remove `.. => [H] ..` patterns.

This patch simplifies the types `branch` and `pattern` by removing the
argument `y : A`, i.e. the discriminee, from their signature. This
argument was used in two places: (1) to type the body of `pany`, and
(2) to type the equality in `.. => [H] ..` patterns, which this patch
removes completely.

Regarding (1): Since `pattern` no longer has access to the discriminee,
this patch changes the type of `pany` to
`(forall x : A, B x) -> pattern A B` and introduces a new pattern notation
written `_ as binder => ..` where the `_` is a fixed token like it was
in the old `_ => ..` notation. This syntax translates to
`pany (fun x => ..)`. When using this notation, `binder` cannot be replaced
by `_` since Coq uses `binder` to type the branch.

Regarding (2): We make little use of the `[H]` and all occurrences
can be replaced by uses of `mtmmatch`, which is surprisingly usable at
this point. Switching to `mtmmatch` currently means that fewer patterns
are available since it has not been ported to the new `branch` and
`pattern` infrastructure. Therefore, some `_ => ..` branches have been
translated to `t =n> ..` where `t` is the discriminee of the match.

### 2. Commit:

Add `_ as _catchall => ..` pattern for `mtmmatch`.

This mirrors the change to `mmatch`'s `pany` and avoids a useless call
to unification from the previous `_ => ..` pattern, which translated to
`[? x] x =n> ..`. (The difference in `_ => ..` patterns was due to
the fact that `mtmmatch`'s infrastructure never had the `y : A` argument
to `(mt)pattern` in the first place.)