### PR TITLE
[8.11] Avoid accidentally reducing `reduce`; refactoring.

### DIFF
--- a/src/run.ml
+++ b/src/run.ml
@@ -1250,11 +1250,12 @@ type vm = Code of CClosure.fconstr
         | Nu of (Names.Id.t * Environ.env * CClosure.fconstr * backtrace)
         | Rem of (Environ.env * CClosure.fconstr * bool)
 
+(* Partition stack st into [cbv] ++ [cbn] such that [cbn] is the longest suffix
+   of matches and projections *)
 let cut_stack st =
   let rec f st acc_cbv acc_cbn =
     match st with
     | ((
-      (* Zfix _ | *)
       Zproj _
     | ZcaseT _
     ) as z) :: st ->
@@ -1267,15 +1268,15 @@ let cut_stack st =
   List.rev acc_cbv_rev, List.rev acc_cbn_rev, r
 
 type context =
-  | CBV
-  | CBN
+  | Monadic
+  | Pure
 
 let rec context_of_stack = function
-  | [] -> CBV
+  | [] -> Monadic
   | ((
     (* Zfix _ | *)
     Zproj _
-  | ZcaseT _)) :: st -> CBN
+  | ZcaseT _)) :: st -> Pure
   | z :: st -> context_of_stack st
 
 let _zip_term m stk =
@@ -1420,7 +1421,7 @@ let rec run' ctxt (vms : vm list) =
 
   | Code t, _ -> (eval[@tailcall]) ctxt vms t
 
-and eval ctxt (vms : vm list) t =
+and eval ctxt (vms : vm list) ?(reduced_to_let=false) t =
   let sigma, env, stack = ctxt.sigma, ctxt.env, ctxt.stack in
 
   let upd c = (Code c :: vms) in
@@ -1441,7 +1442,7 @@ and eval ctxt (vms : vm list) t =
 
   (* Feedback.msg_debug (Pp.int (List.length stack)); *)
 
-  let ctxt = {ctxt with stack=stack} in
+  let ctxt = {ctxt with stack} in
 
   let fail ?internal:(i=true) (sigma, c) =
     let p = Printer.pr_econstr_env env sigma (to_econstr c) in
@@ -1457,8 +1458,8 @@ and eval ctxt (vms : vm list) t =
   let ctx_st = context_of_stack stack in
 
   (* (match ctx_st with
-   * | CBV -> Feedback.msg_debug (Pp.str "cbv")
-   * | CBN -> Feedback.msg_debug (Pp.str "cbn")
+   * | Monadic -> Feedback.msg_debug (Pp.str "monadic")
+   * | Pure -> Feedback.msg_debug (Pp.str "pure")
    * );
    *
    * let term = zip_term (CClosure.term_of_fconstr reduced_term) stack in
@@ -1472,8 +1473,8 @@ and eval ctxt (vms : vm list) t =
   in
 
   match ctx_st, fterm_of reduced_term with
-  | CBV, FConstruct _ -> failwith ("Invariant invalidated: reduction reached the constructor of M.t.")
-  | CBV, FLetIn (_,v,_,bd,e) ->
+  | Monadic, FConstruct _ -> failwith ("Invariant invalidated: reduction reached the constructor of M.t.")
+  | Monadic, FLetIn (_,v,_,bd,e) ->
       let open ReductionStrategy in
       let (is_reduce, num_args, args_clos) = (
         match fterm_of v with
@@ -1506,7 +1507,11 @@ and eval ctxt (vms : vm list) t =
         let e = (Esubst.subs_cons ([|v|], e)) in
         (run'[@tailcall]) ctxt (upd (mk_red (FCLOS (bd, e))))
 
-  | CBV, FFlex (ConstKey (hc, _))
+  | Pure, FLetIn (_,v,_,bd,e) ->
+      let e = (Esubst.subs_cons ([|v|], e)) in
+      (run'[@tailcall]) ctxt (upd (mk_red (FCLOS (bd, e))))
+
+  | Monadic, FFlex (ConstKey (hc, _))
     when (Option.has_some (MConstr.mconstr_head_opt hc)) ->
       begin
         match MConstr.mconstr_head_of hc with
@@ -1518,7 +1523,7 @@ and eval ctxt (vms : vm list) t =
             (primitive[@tailcall]) ctxt vms mh reduced_term
       end
 
-  | CBV, FFlex((ConstKey (hc, _)) as k) ->
+  | Monadic, FFlex((ConstKey (hc, _)) as k) ->
       begin
         let redflags = (CClosure.RedFlags.fCONST hc) in
         let infos = CClosure.infos_with_reds infos (CClosure.RedFlags.mkflags [redflags]) in
@@ -1532,7 +1537,7 @@ and eval ctxt (vms : vm list) t =
             efail (E.mkStuckTerm sigma env (to_econstr t))
       end
 
-  | CBN, (_ as t) when (is_blocked t) ->
+  | Pure, (_ as t) when (is_blocked t) ->
       begin
         if !debug_ex then
           (let open Pp in
@@ -1543,15 +1548,13 @@ and eval ctxt (vms : vm list) t =
         efail (E.mkStuckTerm sigma env (to_econstr reduced_term))
       end
 
-  | CBN, (_ as t) ->
+  | Pure, (_ as t) when not reduced_to_let ->
       let cbv, cbn, r = cut_stack stack in
-      let infos = CClosure.infos_with_reds infos (CClosure.all) in
+      let infos = CClosure.infos_with_reds infos (CClosure.allnolet) in
       let t', stack = reduce_noshare infos tab (CClosure.mk_red t) (List.append cbv cbn) in
-      if Constr.equal (CClosure.term_of_fconstr (mk_red t)) (CClosure.term_of_fconstr t') then
-        efail (E.mkStuckTerm sigma env (to_econstr t'))
-      else
-        let stack = List.append stack r in
-        (run'[@tailcall]) {ctxt with stack} (Code t' :: vms)
+      let stack = List.append stack r in
+      (* signal that we have advanced reduced everything down to lets *)
+      (eval[@tailcall]) {ctxt with stack} vms ?reduced_to_let:(Some true) t'
 
   | _ ->
       efail (E.mkStuckTerm sigma env (to_econstr reduced_term))

--- a/tests/bugs/bug288.v
+++ b/tests/bugs/bug288.v
@@ -1,0 +1,25 @@
+From Mtac2 Require Import Datatypes Mtac2.
+
+Require Import Lists.List.
+Import ListNotations.
+
+(** assert x y e asserts that y is syntactically equal to x. Since we
+need to make sure the convertibility check is not triggered, we assume
+the terms x and/or y contains an evar e that is instantiated with
+tt. *)
+Definition assert_eq {A} (x y: A) : M unit :=
+  o1 <- M.unify x y UniMatchNoRed;
+  match o1 with
+    | mSome _ => M.ret tt
+    | _ => M.raise (NotUnifiable x y)
+  end.
+
+(* Lets in matches used to break let-reduce. *)
+Mtac Do (
+       match (let x := 1 in [x]) with
+       | nil => M.raise exception
+       | cons _ _ =>
+         let n := reduce (RedStrong RedAll) (1 + 1) in
+         assert_eq 2 n
+       end
+     ).


### PR DESCRIPTION
Fixes #287.
Fixes #288 and adds test for it.

Backport of #289.