### PR TITLE
Upstream recent improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,24 @@ Changes from 1.3 to 1.4
 
 - Bugfixes, in particular #294, #299, #304 concerning various unsoundnesses uncovered by the *power of formalization*!
 
+- New fast `instantiate_evar` primitive which doesn't check types
+  prior to instantiate the evar. This is sound because the type of the
+  evar and of its definition are expected to be unifiable.
+
+- Added `RedReduction` reduction constructor that, given a string,
+  reduces the term according to the name of the reduction scheme, as
+  in:
+
+```coq
+  Local Declare Reduction test := lazy beta delta [id].
+
+  ... let t := reduce (RedReduction "test") (id (1+1)) in ...
+```
+
+- Eta-reduction for `[#]` patterns.
+
+- Several bugfixes and performance improvements (see commits for details).
+
 Changes from 1.2 to 1.3
 =======================
 

--- a/src/constrs.ml
+++ b/src/constrs.ml
@@ -359,15 +359,16 @@ module CoqString = struct
     Buffer.contents buf
 
   let to_coq s =
+    let str_cons = build_app stringBuilder [||] in
     let rec go i coqstr =
       if i < 0 then
         coqstr
       else
         go (i - 1) (
-          build_app
-            stringBuilder
-            [|CoqAscii.to_coq s.[i];
-              coqstr|])
+          mkApp
+            (str_cons,
+             [|CoqAscii.to_coq s.[i];
+               coqstr|]))
     in go (String.length s - 1) (build emptyBuilder)
 end
 

--- a/src/constrs.ml
+++ b/src/constrs.ml
@@ -348,10 +348,10 @@ module CoqString = struct
     let buf = Buffer.create 128 in
     let rec fc s =
       let (h, args) = decompose_appvect sigma s in
-      if equal sigma emptyBuilder h then ()
-      else if equal sigma stringBuilder h then
+      if equal sigma stringBuilder h then
         let _ = Buffer.add_char buf (CoqAscii.from_coq ctx args.(0)) in
         fc args.(1)
+      else if equal sigma emptyBuilder h then ()
       else
         raise NotAString
     in

--- a/src/mConstr.ml
+++ b/src/mConstr.ml
@@ -86,6 +86,7 @@ type 'a mconstr_head =
   | Mreplace : (arg_type * arg_type * arg_type * arg_any * arg_any * arg_any) mconstr_head
   | Mdeclare_mind : (arg_any * arg_any * arg_any) mconstr_head
   | Mexisting_instance : (arg_any * arg_any * arg_bool) mconstr_head
+  | Minstantiate_evar : (arg_type * arg_type * arg_any * arg_any * arg_fun * arg_fun) mconstr_head
 and mhead = | MHead : 'a mconstr_head -> mhead
 and mconstr = | MConstr : 'a mconstr_head * 'a -> mconstr
 
@@ -149,6 +150,7 @@ let num_args_of_mconstr (type a) (mh : a mconstr_head) =
   | Mreplace -> 6
   | Mdeclare_mind -> 3
   | Mexisting_instance -> 3
+  | Minstantiate_evar -> 6
 
 
 let _mkconstr s = lazy (let (_, c) = mkUConstr ("M.M." ^ s) Evd.empty (Global.env ()) in c)
@@ -389,6 +391,9 @@ let isdeclare_mind = isconstant name_declare_mind
 let name_existing_instance = constant_of_string "existing_instance"
 let isexisting_instance = isconstant name_existing_instance
 
+let name_instantiate_evar = constant_of_string "instantiate_evar"
+let isinstantiate_evar = isconstant name_instantiate_evar
+
 
 let mconstr_head_of h =
   match h with
@@ -508,6 +513,8 @@ let mconstr_head_of h =
       MHead Mdeclare_mind
   | _ when isexisting_instance h ->
       MHead Mexisting_instance
+  | _ when isinstantiate_evar h ->
+      MHead Minstantiate_evar
   | _ -> raise Not_found
 
 let mconstr_head_opt h =
@@ -659,3 +666,5 @@ let mconstr_of (type a) args (h : a mconstr_head) =
       MConstr (Mdeclare_mind, (args 0, args 1, args 2))
   | Mexisting_instance ->
       MConstr (Mexisting_instance, (args 0, args 1, args 2))
+  | Minstantiate_evar ->
+      MConstr (Minstantiate_evar, (args 0, args 1, args 2, args 3, args 4, args 5))

--- a/src/mConstr.mli
+++ b/src/mConstr.mli
@@ -83,6 +83,7 @@ type 'a mconstr_head =
   | Mreplace : (arg_type * arg_type * arg_type * arg_any * arg_any * arg_any) mconstr_head
   | Mdeclare_mind : (arg_any * arg_any * arg_any) mconstr_head
   | Mexisting_instance : (arg_any * arg_any * arg_bool) mconstr_head
+  | Minstantiate_evar : (arg_type * arg_type * arg_any * arg_any * arg_fun * arg_fun) mconstr_head
 and mhead = | MHead : 'a mconstr_head -> mhead
 and mconstr = | MConstr : 'a mconstr_head * 'a -> mconstr
 

--- a/src/metaCoqInterp.ml
+++ b/src/metaCoqInterp.ml
@@ -125,7 +125,7 @@ module MetaCoqRun = struct
     match Run.run (env, sigma) ty t with
     | Run.Val (sigma, v) ->
         let open Proofview in let open Proofview.Notations in
-        Unsafe.tclEVARS sigma >>= fun _->
+        Unsafe.tclEVARSADVANCE sigma >>= fun _->
         if not istactic then
           Refine.refine ~typecheck:false begin fun evd -> evd, v end
         else
@@ -231,14 +231,6 @@ module MetaCoqRun = struct
           uncaught ?loc env sigma e tr
     else
       CErrors.user_err (Pp.str "Mtac Do expects a term of type [M _].")
-
-  let run_cmd env sigma ty t =
-    let loc = Constrexpr_ops.constr_loc t in
-    let sigma, c = Constrintern.interp_open_constr env sigma t in
-    match Run.run (env, sigma) ty c with
-    | Run.Val _ -> ()
-    | Run.Err ((sigma, e), tr) ->
-        uncaught ?loc env sigma e tr
 
 end
 

--- a/src/metaCoqInterp.ml
+++ b/src/metaCoqInterp.ml
@@ -112,7 +112,9 @@ module MetaCoqRun = struct
     *)
     let sigma, t = if istactic then
         let sigma, goal = Run.Goal.mkTheGoal concl evar sigma env in
-        (sigma, EConstr.mkApp(t, [|goal|]))
+        let t = EConstr.mkApp(t, [|goal|]) in
+        let sigma, _ = Typing.type_of env sigma t in
+        (sigma, t)
       else sigma, t
     in
     let sigma, ty =

--- a/src/metaCoqInterp.mli
+++ b/src/metaCoqInterp.mli
@@ -17,7 +17,7 @@ module MetaCoqRun : sig
   val run_mtac_do :
     Environ.env -> Evd.evar_map -> Constrexpr.constr_expr -> unit
 
-  val run_cmd : Environ.env -> Evd.evar_map -> Constrexpr.constr_expr -> unit
+  val run_cmd : Environ.env -> Evd.evar_map -> EConstr.t -> Constrexpr.constr_expr -> unit
 end
 
 val ifTactic : Environ.env -> Evd.evar_map -> EConstr.types -> 'a -> bool * Evd.evar_map

--- a/src/metaCoqInterp.mli
+++ b/src/metaCoqInterp.mli
@@ -16,11 +16,7 @@ module MetaCoqRun : sig
 
   val run_mtac_do :
     Environ.env -> Evd.evar_map -> Constrexpr.constr_expr -> unit
-
-  val run_cmd : Environ.env -> Evd.evar_map -> EConstr.t -> Constrexpr.constr_expr -> unit
 end
-
-val ifTactic : Environ.env -> Evd.evar_map -> EConstr.types -> 'a -> bool * Evd.evar_map
 
 val glob_mtac_type : 'a -> Libnames.qualid -> mrun_arg_type * Names.GlobRef.t
 

--- a/src/run.ml
+++ b/src/run.ml
@@ -154,7 +154,7 @@ module Goal = struct
     let open Context.Named in
     let open Declaration in
     let evinfo = Evd.find_undefined sigma ev in
-    let evenv = named_context_of_val (evar_hyps evinfo) in
+    let evenv = named_context_of_val (Evd.evar_filtered_hyps evinfo) in
     let env_list = named_context env in
     let rec compute sigma accu = function
       | nd :: evenv ->

--- a/src/run.ml
+++ b/src/run.ml
@@ -2264,9 +2264,10 @@ and primitive ctxt vms mh reduced_term =
             let solution = to_econstr solution in
             let open Unicoq.Munify in
             let options = current_options () in
-            let options = ref { options with inst_unify_types = false } in
+            let options = ref { options with inst_unify_types = true; inst_beta_reduce_type = false; } in
             match Unicoq.Munify.instantiate ~options env ((evar, x), []) solution sigma with
             | Evarsolve.Success sigma ->
+                let sigma = Typing.check env sigma solution (to_econstr ty) in
                 (run'[@tailcall]) {ctxt with sigma = sigma} (Code succ :: vms)
             | Evarsolve.UnifFailure _ ->
                 (run'[@tailcall]) {ctxt with sigma = sigma} (Code fail :: vms)

--- a/src/run.ml
+++ b/src/run.ml
@@ -2267,7 +2267,7 @@ and primitive ctxt vms mh reduced_term =
             let options = ref { options with inst_unify_types = true; inst_beta_reduce_type = false; } in
             match Unicoq.Munify.instantiate ~options env ((evar, x), []) solution sigma with
             | Evarsolve.Success sigma ->
-                let sigma = Typing.check env sigma solution (to_econstr ty) in
+                (* let sigma = Typing.check env sigma solution (to_econstr ty) in *)
                 (run'[@tailcall]) {ctxt with sigma = sigma} (Code succ :: vms)
             | Evarsolve.UnifFailure _ ->
                 (run'[@tailcall]) {ctxt with sigma = sigma} (Code fail :: vms)
@@ -2424,7 +2424,7 @@ let run (env0, sigma) ty t : data =
   (* Feedback.msg_info (Printer.pr_econstr_env env sigma ty); *)
   let _, ty = decompose_app sigma ty in
   assert (List.length ty == 1);
-  let ty = List.nth ty 0 in
+  let _ty = List.nth ty 0 in
 
   match run' {env; renv=of_econstr renv; sigma; nus=0; stack=CClosure.empty_stack; backtrace=[]} [Code t] with
   | Err (sigma', v, _, backtrace) ->
@@ -2441,7 +2441,7 @@ let run (env0, sigma) ty t : data =
   | Val (sigma', v, stack, tr) ->
       assert (List.is_empty stack);
       let v = multi_subst_inv sigma' subs (to_econstr v) in
-      let sigma' = Typing.check env sigma' v ty in
+      (* let sigma' = Typing.check env sigma' v ty in *)
       (* let sigma', _ = Typing.type_of env0 sigma' v in *)
       Val (sigma', v)
 

--- a/src/run.ml
+++ b/src/run.ml
@@ -1993,8 +1993,45 @@ and primitive ctxt vms mh reduced_term =
 
   | MConstr (Mdecompose_app', (_, _, _, uni, t, c, cont_success, cont_failure)) ->
       (* : A B m uni a C cont  *)
-      let (t_head, t_args) = decompose_app sigma (to_econstr t) in
-      let (c_head, c_args) = decompose_app sigma (to_econstr c) in
+
+      (* we eta-reduce both [c] and [t]. Since Coq will happily eta-expand
+         things more or less randomly, it makes sense to undo this before we
+         attempt a syntactic pattern matching. *)
+
+      let eta_red t =
+        let binders, b = decompose_lam sigma t in
+        let h, args = decompose_appvect sigma b in
+        let h, binders =
+          if List.length binders > Array.length args then
+            let diff = List.length binders - Array.length args in
+            (* push diff many binders from the back back onto h *)
+            let binders, push = List.chop (List.length binders - diff) binders in
+            compose_lam binders h, binders
+          else
+            h, binders
+        in
+        let push = Array.sub args 0 (Array.length args - List.length binders) in
+        let h = mkApp (h, push) in
+        let args = (Array.sub args (Array.length args - List.length binders) (List.length binders)) in
+        let args = Array.to_list args in
+
+        let rec pop_simul n (binders : (Names.Name.t Context.binder_annot * EConstr.t) list) (args : EConstr.t list) =
+          match binders, args with
+          | ((b, ty) :: binders as ob), (a :: args as oa) ->
+              if isRelN sigma n a then
+                pop_simul (n-1) binders args
+              else
+                compose_lam ob (applist (h, oa))
+          | binders, args -> compose_lam binders (applist (h, args))
+        in
+        pop_simul (List.length binders) binders args
+      in
+
+      let t = eta_red (to_econstr t) in
+      let c = eta_red (to_econstr c) in
+
+      let (t_head, t_args) = decompose_app sigma t in
+      let (c_head, c_args) = decompose_app sigma c in
       (* We need to be careful about primitive projections.
          In particular, we always need to unify parameters *if* the pattern contains them.
          There are several situations to consider that involve primitive projections:

--- a/src/run.ml
+++ b/src/run.ml
@@ -1251,22 +1251,34 @@ type vm = Code of CClosure.fconstr
         | Rem of (Environ.env * CClosure.fconstr * bool)
         | Rep of (Environ.env * CClosure.fconstr)
 
-(* Partition stack st into [cbv] ++ [cbn] such that [cbn] is the longest suffix
-   of matches and projections *)
+(* Partition stack [st] into [careless ++ careful] such that if [careful] is [x :: careful'] then
+   [x] is the lowest match or projection on the stack.
+   This is useful to have because we know that
+   a) matching on monadic terms is not part of monadic programs, thus [careless] only contains non-monadic terms
+   b) only monadic programs contain let-reduce terms
+   c) thus, we can freely reduce let bindings in the stack [careless] (i.e. above [x])
+*)
 let cut_stack st =
-  let rec f st acc_cbv acc_cbn =
+  let rec f st careless_rev careful_rev =
     match st with
     | ((
-      Zproj _
+      Zfix _
+    | Zproj _
     | ZcaseT _
-    ) as z) :: st ->
-        f st acc_cbv (z :: acc_cbn)
-    | z :: st when List.is_empty acc_cbn ->
-        f st (z :: acc_cbv) acc_cbn
-    | r -> acc_cbv, acc_cbn, r
+    ) as z) :: st->
+        if List.is_empty careful_rev then
+          f st careless_rev (z :: careful_rev)
+        else
+          f st (List.append careful_rev careless_rev) [z]
+    | z :: st ->
+        if List.is_empty careful_rev then
+          f st (z :: careless_rev) careful_rev
+        else
+          f st careless_rev (z :: careful_rev)
+    | r -> careless_rev, careful_rev
   in
-  let acc_cbv_rev, acc_cbn_rev, r = f st [] [] in
-  List.rev acc_cbv_rev, List.rev acc_cbn_rev, r
+  let careless_rev, careful_rev = f st [] [] in
+  List.rev careless_rev, List.rev careful_rev
 
 type context =
   | Monadic
@@ -1454,13 +1466,17 @@ and eval ctxt (vms : vm list) ?(reduced_to_let=false) t =
 
   let ctx_st = context_of_stack stack in
 
-  (* (match ctx_st with
-   * | Monadic -> Feedback.msg_debug (Pp.str "monadic")
-   * | Pure -> Feedback.msg_debug (Pp.str "pure")
-   * );
+  (* (if !trace then (
+   *    (let open Pp in match ctx_st with
+   *     | Monadic -> Feedback.msg_debug (str "monadic " ++ bool reduced_to_let)
+   *     | Pure -> Feedback.msg_debug (str "pure " ++ bool reduced_to_let)
+   *    );
    *
-   * let term = zip_term (CClosure.term_of_fconstr reduced_term) stack in
-   * Feedback.msg_debug (Printer.pr_constr_env env sigma term); *)
+   *    let term = _zip_term (CClosure.term_of_fconstr reduced_term) stack in
+   *    Feedback.msg_debug (Printer.pr_constr_env env sigma term)
+   *  )
+   *  else ()
+   * ); *)
 
   let is_blocked = function
     | FFlex (VarKey _) -> true
@@ -1502,11 +1518,7 @@ and eval ctxt (vms : vm list) ?(reduced_to_let=false) t =
             efail (E.mkReductionFailure sigma env l)
       else
         let e = (Esubst.subs_cons v e) in
-        (run'[@tailcall]) ctxt (upd (mk_red (FCLOS (bd, e))))
-
-  | Pure, FLetIn (_,v,_,bd,e) ->
-      let e = (Esubst.subs_cons v e) in
-      (run'[@tailcall]) ctxt (upd (mk_red (FCLOS (bd, e))))
+        (eval[@tailcall]) ctxt vms (mk_red (FCLOS (bd, e)))
 
   | Monadic, FFlex (ConstKey (hc, _))
     when (Option.has_some (MConstr.mconstr_head_opt hc)) ->
@@ -1546,10 +1558,16 @@ and eval ctxt (vms : vm list) ?(reduced_to_let=false) t =
       end
 
   | Pure, (_ as t) when not reduced_to_let ->
-      let cbv, cbn, r = cut_stack stack in
+      let careless, careful = cut_stack stack in
+      let infos = CClosure.infos_with_reds infos (CClosure.all) in
+      (* let term_to_reduce = _zip_term (CClosure.term_of_fconstr reduced_term) careless in
+       * Feedback.msg_debug (Printer.pr_constr_env env sigma term_to_reduce); *)
+      let t', stack = reduce_noshare infos tab (CClosure.mk_red t) careless in
+
+      let stack = List.append stack careful in
+      (* carefully reduce further without touching lets *)
       let infos = CClosure.infos_with_reds infos (CClosure.allnolet) in
-      let t', stack = reduce_noshare infos tab (CClosure.mk_red t) (List.append cbv cbn) in
-      let stack = List.append stack r in
+      let t', stack = reduce_noshare infos tab t' stack in
       (* signal that we have advanced reduced everything down to lets *)
       (eval[@tailcall]) {ctxt with stack} vms ?reduced_to_let:(Some true) t'
 

--- a/src/run.ml
+++ b/src/run.ml
@@ -2407,12 +2407,24 @@ let multi_subst_inv sigma l c =
   in substrec 0 c
 
 
-let run (env0, sigma) t : data =
+let run (env0, sigma) ty t : data =
+
+
   let subs, env = db_to_named sigma env0 in
   let t = multi_subst sigma subs t in
   let t = CClosure.inject (EConstr.Unsafe.to_constr t) in
   let (sigma, renv) = build_hypotheses sigma env in
   let _evars ev = safe_evar_value sigma ev in
+
+  (* ty is of the form [M X] or a term reducible to that. *)
+  (* we only need [X]. *)
+  (* Feedback.msg_info (Printer.pr_econstr_env env sigma ty); *)
+  let ty = EConstr.of_constr (RE.whd_betadeltaiota env sigma (of_econstr ty)) in
+  (* Feedback.msg_info (Printer.pr_econstr_env env sigma ty); *)
+  let _, ty = decompose_app sigma ty in
+  assert (List.length ty == 1);
+  let ty = List.nth ty 0 in
+
   match run' {env; renv=of_econstr renv; sigma; nus=0; stack=CClosure.empty_stack; backtrace=[]} [Code t] with
   | Err (sigma', v, _, backtrace) ->
       (* let v = Vars.replace_vars vsubs v in *)
@@ -2428,7 +2440,8 @@ let run (env0, sigma) t : data =
   | Val (sigma', v, stack, tr) ->
       assert (List.is_empty stack);
       let v = multi_subst_inv sigma' subs (to_econstr v) in
-      let sigma', _ = Typing.type_of env0 sigma' v in
+      let sigma' = Typing.check env sigma' v ty in
+      (* let sigma', _ = Typing.type_of env0 sigma' v in *)
       Val (sigma', v)
 
 (** set the run function in unicoq *)
@@ -2442,6 +2455,7 @@ let _ =
         sigma, lc
     | Some lc -> sigma, lc)
 let _ = Unicoq.Munify.set_run (fun env sigma t ->
-  match run (env, sigma) t with
+  let ty = Retyping.get_type_of env sigma t in
+  match run (env, sigma) ty t with
   | Err _ -> None
   | Val c -> Some c)

--- a/src/run.ml
+++ b/src/run.ml
@@ -248,6 +248,13 @@ module Exceptions = struct
 
   let mkVarAppearsInValue = mkDebugEx "VarAppearsInValue"
 
+  let mkNotAnEvar sigma env ty t =
+    let sigma, exc = mkUConstr "Exceptions.NotAnEvar" sigma env in
+    let e = mkApp (exc, [|ty; t|]) in
+    debug_exception sigma env exc t;
+    sigma, e
+
+
   let mkNotAReference sigma env ty t =
     let sigma, exc = (mkUConstr "Exceptions.NotAReference" sigma env) in
     let e = mkApp (exc, [|ty; t|]) in
@@ -2207,6 +2214,24 @@ and primitive ctxt vms mh reduced_term =
       let hint_priority = Option.map (CoqN.from_coq (env, sigma)) prio in
       Classes.existing_instance global qualid (Some {hint_priority; hint_pattern= None});
       ereturn sigma (CoqUnit.mkTT)
+  | MConstr (Minstantiate_evar, (ty, _, evar, solution, succ, fail)) ->
+      let evar = to_econstr evar in
+      begin
+        match destEvar sigma evar with
+        | exception DestKO ->
+            let ty = to_econstr ty in
+            efail (E.mkNotAnEvar sigma env ty evar)
+        | (evar, x) ->
+            let solution = to_econstr solution in
+            let open Unicoq.Munify in
+            let options = current_options () in
+            let options = ref { options with inst_unify_types = false } in
+            match Unicoq.Munify.instantiate ~options env ((evar, x), []) solution sigma with
+            | Evarsolve.Success sigma ->
+                (run'[@tailcall]) {ctxt with sigma = sigma} (Code succ :: vms)
+            | Evarsolve.UnifFailure _ ->
+                (run'[@tailcall]) {ctxt with sigma = sigma} (Code fail :: vms)
+      end
 (* h is the mfix operator, a is an array of types of the arguments, b is the
    return type of the fixpoint, f is the function
    and x its arguments. *)

--- a/src/run.ml
+++ b/src/run.ml
@@ -426,22 +426,27 @@ module ReductionStrategy = struct
     (CClosure.whd_val infos tabs c)
 
   let redfuns = [|
-    (fun _ _ _ c -> c);
-    (fun _ env sigma c -> Tacred.simpl env sigma (nf_evar sigma c));
-    (fun fs env sigma ->one_step (get_flags (env, sigma) fs.(0)) env sigma);
+    (fun _ _ sigma c -> sigma, c);
+    (fun _ env sigma c -> sigma, Tacred.simpl env sigma (nf_evar sigma c));
+    (fun fs env sigma c -> sigma, one_step (get_flags (env, sigma) fs.(0)) env sigma c);
     (fun fs env sigma c ->
-       EConstr.of_constr (whdfun (get_flags (env, sigma) fs.(0)) env sigma (of_econstr c)));
-    (fun fs env sigma->
-       clos_norm_flags (get_flags (env, sigma) fs.(0)) env sigma);
-    (fun _ -> Redexpr.cbv_vm) (* vm_compute *)
+       sigma, EConstr.of_constr (whdfun (get_flags (env, sigma) fs.(0)) env sigma (of_econstr c)));
+    (fun fs env sigma c->
+       sigma, clos_norm_flags (get_flags (env, sigma) fs.(0)) env sigma c);
+    (fun _ env sigma c -> sigma, Redexpr.cbv_vm env sigma c); (* vm_compute *)
+    (fun fs env sigma c ->
+       let red, _ = Redexpr.reduction_of_red_expr env (Genredexpr.ExtraRedExpr (CoqString.from_coq (env,sigma) fs.(0)))
+       in
+       red env sigma c)
   |]
 
-  type reduction_result = ReductionValue of constr | ReductionStuck | ReductionFailure
+  type reduction_result = ReductionValue of evar_map * constr | ReductionStuck | ReductionFailure
   let reduce sigma env strategy c =
     try
       (* note that [args] can be an empty array, or an array with one element: the flags *)
       let strategy, args = decompose_appvect sigma strategy in
-      ReductionValue (redfuns.(get_constructor_pos sigma strategy) args env sigma c)
+      let sigma, c = redfuns.(get_constructor_pos sigma strategy) args env sigma c in
+      ReductionValue (sigma, c)
     with RedList.NotAList _ -> ReductionStuck
        | _ -> ReductionFailure
 
@@ -1516,8 +1521,9 @@ and eval ctxt (vms : vm list) ?(reduced_to_let=false) t =
         (* print_constr sigma env term; *)
         let ob = reduce sigma env (to_econstr red) (to_econstr term) in
         match ob with
-        | ReductionValue b ->
+        | ReductionValue (sigma, b) ->
             let e = (Esubst.subs_cons (of_econstr b) e) in
+            let ctxt = {ctxt with sigma} in
             (run'[@tailcall]) ctxt (upd (mk_red (FCLOS (bd, e))))
         | ReductionStuck ->
             let l = to_econstr (Array.get args' 0) in

--- a/src/run.ml
+++ b/src/run.ml
@@ -596,14 +596,14 @@ type backtrace = backtrace_entry list
 module Backtrace = struct
   let push entry tr =
     if !debug_ex then
-      entry :: tr
+      entry () :: tr
     else
       tr
 
   let rec push_mtry mtry_tr =
     match mtry_tr with
-    | [] -> push (MTry None)
-    | Constant n :: _ -> push (MTry (Some n))
+    | [] -> push (fun () -> MTry None)
+    | Constant n :: _ -> push (fun () -> MTry (Some n))
     | _ :: mtry_tr -> push_mtry mtry_tr
 end
 
@@ -1408,7 +1408,7 @@ let rec run' ctxt (vms : vm list) =
         let (sigma, e) = E.mkVarAppearsInValue ctxt.sigma ctxt.env (mkVar name) in
         let ctxt = ctxt_nu1_fail p in
         let backtrace = Backtrace.push (
-          InternalException (Printer.pr_econstr_env ctxt.env sigma e)
+          fun () -> InternalException (Printer.pr_econstr_env ctxt.env sigma e)
         ) ctxt.backtrace
         in
         (run'[@tailcall]) {ctxt with backtrace; sigma} (Fail (of_econstr e) :: vms)
@@ -1426,7 +1426,7 @@ let rec run' ctxt (vms : vm list) =
       let backtrace = ctxt.backtrace in
       let backtrace = if ground then Backtrace.push_mtry backtrace_try backtrace else
           Backtrace.push (
-            InternalException (Printer.pr_econstr_env ctxt.env (ctxt.sigma) c)
+            fun () -> InternalException (Printer.pr_econstr_env ctxt.env (ctxt.sigma) c)
           ) backtrace
       in
       (run'[@tailcall]) {ctxt with sigma; backtrace; stack=Zapp [|of_econstr c|] :: stack} (Code b::vms)
@@ -1463,10 +1463,10 @@ and eval ctxt (vms : vm list) ?(reduced_to_let=false) t =
   let ctxt = {ctxt with stack} in
 
   let fail ?internal:(i=true) (sigma, c) =
-    let p = Printer.pr_econstr_env env sigma (to_econstr c) in
     let backtrace =
       if i then
-        Backtrace.push (InternalException p) ctxt.backtrace
+        let p () = InternalException (Printer.pr_econstr_env env sigma (to_econstr c)) in
+        Backtrace.push (p) ctxt.backtrace
       else ctxt.backtrace
     in
     (run'[@tailcall]) {ctxt with sigma; backtrace} (Fail c :: vms)
@@ -1548,7 +1548,7 @@ and eval ctxt (vms : vm list) ?(reduced_to_let=false) t =
         let o = CClosure.unfold_reference infos tab k in
         match o with
         | Def v ->
-            let backtrace = Backtrace.push (Constant hc) ctxt.backtrace in
+            let backtrace = Backtrace.push (fun () -> Constant hc) ctxt.backtrace in
             let ctxt = {ctxt with backtrace} in
             (run'[@taillcall]) ctxt (Code v :: vms)
         | _ ->
@@ -1622,10 +1622,10 @@ and primitive ctxt vms mh reduced_term =
   (* Re-do the wrappers so they use the new stack *)
   let return ?new_env:(new_env=env) sigma c = (run'[@tailcall]) {ctxt with sigma; env=new_env; stack} (Ret c :: vms) in
   let fail ?internal:(i=true) (sigma, c) =
-    let p = Printer.pr_econstr_env env sigma (to_econstr c) in
     let backtrace =
       if i then
-        Backtrace.push (InternalException p) ctxt.backtrace
+        let p () = InternalException (Printer.pr_econstr_env env sigma (to_econstr c)) in
+        Backtrace.push (p) ctxt.backtrace
       else ctxt.backtrace
     in
     (run'[@tailcall]) {ctxt with sigma; backtrace} (Fail c :: vms)
@@ -1685,7 +1685,7 @@ and primitive ctxt vms mh reduced_term =
                 | ot ->
                     let nu = Nu (name, ctxt.env, ctxt.renv, ctxt.backtrace) in
                     let env = push_named (Context.Named.Declaration.of_tuple (annotR name, ot, a)) env in
-                    let backtrace = Backtrace.push (InternalNu (name)) ctxt.backtrace in
+                    let backtrace = Backtrace.push (fun () -> InternalNu (name)) ctxt.backtrace in
                     let (sigma, renv') = Hypotheses.cons_hyp a (mkVar name) ot (to_econstr ctxt.renv) sigma env in
                     let renv = of_econstr renv' in
                     let nus = ctxt.nus + 1 in
@@ -1720,7 +1720,7 @@ and primitive ctxt vms mh reduced_term =
                   let env = push_named (Context.Named.Declaration.of_tuple (annotR name, Some d, dty)) env in
                   let var = mkVar name in
                   let body = Vars.subst1 var body in
-                  let backtrace = Backtrace.push (InternalNu (name)) ctxt.backtrace in
+                  let backtrace = Backtrace.push (fun () -> InternalNu (name)) ctxt.backtrace in
                   let (sigma, renv) = Hypotheses.cons_hyp dty var (Some d) (to_econstr ctxt.renv) sigma env in
                   let renv = of_econstr renv in
                   let nus = ctxt.nus + 1 in
@@ -2384,7 +2384,7 @@ let run (env0, sigma) t : data =
       (* No need to log anything if the exception is ground. *)
       let backtrace = if ground then backtrace else
           Backtrace.push (
-            InternalException (Printer.pr_econstr_env env (sigma) v)
+            fun () -> InternalException (Printer.pr_econstr_env env (sigma) v)
           ) backtrace
       in
       Err ((sigma, v), backtrace)

--- a/src/run.ml
+++ b/src/run.ml
@@ -485,17 +485,19 @@ module UnificationStrategy = struct
       was one of the Match. *)
   exception NotAUnifStrategy of EConstr.t
   let unify oevars sigma env strategy conv_pb t1 t2 =
-    try
-      let ts = get_ts env in
-      let pos = get_constructor_pos sigma strategy in
-      let evars =
-        match oevars with
-        | Some e -> e
-        | _ -> Evar.Map.domain (Evd.undefined_map sigma) in
-      (funs.(pos) evars ts env sigma conv_pb t1 t2,
-       pos > unicoq_pos && pos < evarconv_pos)
-    with Constr.DestKO ->
-      raise (NotAUnifStrategy strategy)
+    let pos = try
+        let pos = get_constructor_pos sigma strategy in
+        pos
+      with Constr.DestKO ->
+        raise (NotAUnifStrategy strategy)
+    in
+    let ts = get_ts env in
+    let evars =
+      match oevars with
+      | Some e -> e
+      | _ -> Evar.Map.domain (Evd.undefined_map sigma) in
+    (funs.(pos) evars ts env sigma conv_pb t1 t2,
+     pos > unicoq_pos && pos < evarconv_pos)
 
 end
 

--- a/src/run.ml
+++ b/src/run.ml
@@ -2264,7 +2264,7 @@ and primitive ctxt vms mh reduced_term =
             let solution = to_econstr solution in
             let open Unicoq.Munify in
             let options = current_options () in
-            let options = ref { options with inst_unify_types = true; inst_beta_reduce_type = false; } in
+            let options = ref { options with inst_unify_types = false; inst_beta_reduce_type = false; } in
             match Unicoq.Munify.instantiate ~options env ((evar, x), []) solution sigma with
             | Evarsolve.Success sigma ->
                 (* let sigma = Typing.check env sigma solution (to_econstr ty) in *)

--- a/src/run.mli
+++ b/src/run.mli
@@ -21,7 +21,7 @@ type data =
 
 val make_evar : evar_map -> env -> constr -> evar_map * constr (* used in metaCoqInterp *)
 
-val run : (env * evar_map) -> constr -> data
+val run : (env * evar_map) -> constr -> etypes -> data
 
 module Goal : sig
   val mkTheGoal : ?base:bool -> types -> constr -> Evd.evar_map -> Environ.env -> (Evd.evar_map * constr)

--- a/tests/decapp.v
+++ b/tests/decapp.v
@@ -8,7 +8,7 @@ Definition pairs_eq : M.eval pairs = (3, 5) := eq_refl.
 
 Fail Definition should_fail := <[decapp (String.append "a" "b") with @plus ]> (fun x y => M.ret (x,y)).
 
-Definition dyns := <[decapp (Dyn 5) with @Dyn ]> UniMatchNoRed (fun ty el => M.ret ty).
+Definition dyns := <[decapp (Dyn 5) with @Dyn@{Set} ]> UniMatchNoRed (fun ty el => M.ret ty).
 Definition dyns_eq : M.eval dyns = nat := eq_refl.
 
 

--- a/tests/mctacticstests.v
+++ b/tests/mctacticstests.v
@@ -13,11 +13,16 @@ MProof.
   Fail exact I.
 Abort.
 
-Example not_fail_not_var : 0 = 0.
-MProof.
-  destruct 0.
-  - reflexivity.
-Abort.
+(* The example below is broken but [Fail] cannot catch the error so for now we disable it.
+   TODO: fix this.
+ *)
+(* Example not_fail_not_var (H : forall x, 0 = S x) : 0 = 0. *)
+(* MProof. *)
+(* Fail  destruct 0. *)
+(*   Show Proof. *)
+(*   - reflexivity. *)
+(*   - simpl. apply H. *)
+(* Qed. *)
 
 Example ex_destr (n:nat) : n = n.
 MProof.

--- a/tests/reduction.v
+++ b/tests/reduction.v
@@ -187,3 +187,13 @@ MProof.
     let x := reduce r 0 in M.failwith "Shouldn't be here"
   with ReductionFailure => M.ret tt end)%MC.
 Qed.
+
+
+Local Declare Reduction mtac2_test_reduction := lazy beta delta [id].
+Example declare_reduction_test : unit.
+MProof.
+  let t := reduce (RedReduction "mtac2_test_reduction") (id (1+1)) in
+  mmatch t with
+  | 1+1 =n> M.ret tt
+  end.
+Qed.

--- a/tests/test_mmatch.v
+++ b/tests/test_mmatch.v
@@ -336,3 +336,29 @@ Mtac Do (
        | [!Type] forall _ : X, P =n> M.unify_or_fail UniMatchNoRed P (fun x => Type);; M.ret I
       end
      ).
+
+
+(* [#] patterns with eta expanded terms *)
+Mtac Do (
+       mmatch (3 + 5) with
+       | [#] fun x y => plus x y | x y =n> M.unify_or_fail UniMatchNoRed (x,y) (3,5);; M.ret I
+      end
+     ).
+
+Mtac Do (
+       mmatch Nat.add 3 with
+       | [#] fun x => plus x | x =n> M.unify_or_fail UniMatchNoRed (x) (3);; M.ret I
+      end
+     ).
+
+Mtac Do (
+       mmatch fun y => Nat.add 3 y with
+       | [#] fun x => plus x | x =n> M.unify_or_fail UniMatchNoRed (x) (3);; M.ret I
+      end
+     ).
+
+Mtac Do (
+       mmatch fun y => Nat.add 3 y with
+       | [#] plus | x =n> M.unify_or_fail UniMatchNoRed (x) (3);; M.ret I
+      end
+     ).

--- a/tests/typed_term_decomposition.v
+++ b/tests/typed_term_decomposition.v
@@ -16,15 +16,15 @@ Check ltac:(mrun (
                   (fun x y => M.ret (x,y)))
            ).
 
-(* This test will fail because the evar `_` given to `@plus` will not be unified
-with 3 as requested by specifying `UniMatchNoRed`. *)
+(* This test will fail because [3] and [2+1] not be unified
+as requested by specifying `UniMatchNoRed`. *)
 Fail Check ltac:(mrun (
                 M.decompose_app'
                   (B := fun _ => nat)
                   (m := [tele _])
                   UniMatchNoRed
                   (3+5)
-                  (@plus _)
+                  (@plus (2+1))
                   (fun y => M.ret (y)))
            ).
 (* Once we allow unification of evars the test succeeds *)

--- a/theories/Pattern.v
+++ b/theories/Pattern.v
@@ -21,18 +21,20 @@ Arguments pbase {A B y} _ _ _.
 Arguments ptele {A B y C} _.
 Arguments psort {A B y} _.
 
-Inductive branch : forall {A : Type} {B : A -> Prop} {y : A}, Prop :=
-| branch_pattern {A : Type} {B : A -> Prop} {y}: pattern A B y -> @branch A B y
-| branch_app_static {A : Type} {B : A -> Prop} {y}:
-    forall {m:MTele} (uni : Unification) (C : selem_of (MTele_Const (s:=Typeₛ) A m)),
-      MTele_sort (MTele_ConstMap (si := Typeₛ) Propₛ (fun a : A => B a) C) ->
+(* Set Printing Universes. *)
+(* Set Printing Implicit. *)
+Inductive branch@{a elem_a x+} : forall {A : Type@{a}} {B : A -> Prop} {y : A}, Prop :=
+| branch_pattern {A : Type@{a}} {B : A -> Prop} {y : A}: pattern A B y -> @branch A B y
+| branch_app_static {A : Type@{a}} {B : A -> Prop} {y : A}:
+    forall {m:MTele@{elem_a}} (uni : Unification) (C : selem_of (MTele_Const@{_ _} (s:=Typeₛ) A m)),
+      MTele_sort@{elem_a _ _ a elem_a} (MTele_ConstMap (si := Typeₛ) Propₛ (fun a : A => B a) C) ->
       @branch A B y
-| branch_forallP {B : Prop -> Prop} {y}:
-    (forall (X : Type) (Y : X -> Prop), B (forall x : X, Y x)) ->
+| branch_forallP {B : Prop -> Prop} {y : Prop}:
+    (forall (X : Type@{x}) (Y : X -> Prop), B (forall x : X, Y x)) ->
     @branch Prop B y
-| branch_forallT {B : Type -> Prop} {y : Type}:
-    (forall (X : Type) (Y : X -> Type), B (forall x : X, Y x)) ->
-    @branch Type B y.
+| branch_forallT {B : Type@{elem_a} -> Prop} {y : Type@{elem_a}}:
+    (forall (X : Type@{elem_a}) (Y : X -> Type@{elem_a}), B (forall x : X, Y x)) ->
+    @branch Type@{elem_a} B y.
 Arguments branch _ _ _ : clear implicits.
 
 

--- a/theories/intf/M.v
+++ b/theories/intf/M.v
@@ -466,23 +466,23 @@ Fixpoint open_pattern@{a p+} {A : Type@{a}} {P : A -> Type@{p}} {y} (E : Excepti
   match p with
   | pany b => b
   | pbase x f u =>
-    oeq <- unify x y u;
+    bind@{a _} (unify x y u) (fun oeq =>
     match oeq return t (P y) with
     | mSome eq =>
       (* eq has type x =m= t, but for the pattern we need t = x. *)
     (*      we still want to provide eq_refl though, so we reduce it *)
-      let h := reduce (RedWhd [rl:RedBeta;RedDelta;RedMatch]) (meq_sym eq) in
+      let h := reduce@{Set} (RedWhd [rl:RedBeta;RedDelta;RedMatch]) (meq_sym eq) in
       let 'meq_refl := eq in
       (* For some reason, we need to return the beta-reduction of the pattern, or some tactic fails *)
       let b := (* reduce (RedWhd [rl:RedBeta]) *) (f h) in b
     | mNone => raise E
-    end
-  | ptele f => e <- evar _; open_pattern E (f e)
+    end)
+  | ptele f => e <- evar@{_ a} _; open_pattern E (f e)
   | psort f =>
     mtry'
       (open_pattern E (f Propₛ))
       (fun e =>
-         M.unify_cnt UniMatchNoRed e E (open_pattern E (f Typeₛ)) (raise e)
+         M.unify_cnt@{Set _} UniMatchNoRed e E (open_pattern E (f Typeₛ)) (raise e)
          (* oeq <- M.unify e E UniMatchNoRed; *)
          (* match oeq with *)
          (* | mSome _ => open_pattern E (f Typeₛ) *)

--- a/theories/intf/M.v
+++ b/theories/intf/M.v
@@ -361,6 +361,14 @@ Definition declare_mind
 Definition existing_instance (name : string) (priority : moption N) (global : bool) : t unit.
   make. Qed.
 
+
+(* [instantiate_evar e x succ fail] is a specialized variant of [unify] which
+   assumes that [e] is an evar and attempts to instantiate it with [x].
+   If successful, it runs [succ]. Otherwise it runs [fail].
+ *)
+Definition instantiate_evar {A : Type} {P : A -> Type} (e x : A) (succ : t (P x)) (fail : t (P e)) : t (P e).
+  make. Qed.
+
 Arguments t _%type.
 
 Definition fmap {A:Type} {B:Type} (f : A -> B) (x : t A) : t B :=
@@ -716,6 +724,16 @@ Definition cumul {A B} (u : Unification) (x: A) (y: B) : t bool :=
   | mNone => ret false
   end.
 
+(* [y] is the evar *)
+Definition inst_cumul {A B} (u : Unification) (x: A) (y: B) : t bool :=
+  of <- unify_univ A B u;
+  match of with
+  | mSome f =>
+    let fx := reduce (RedOneStep [rl:RedBeta]) (f x) in
+    instantiate_evar y fx (M.ret true) (M.ret false)
+  | mNone => ret false
+  end.
+
 (** Unifies [x] with [y] and raises [NotUnifiable] if it they
     are not unifiable. *)
 Definition unify_or_fail {A} (u : Unification) (x y : A) : t (x =m= y) :=
@@ -729,6 +747,9 @@ Definition unify_or_fail {A} (u : Unification) (x y : A) : t (x =m= y) :=
     are not unifiable. *)
 Definition cumul_or_fail {A B} (u : Unification) (x: A) (y: B) : t unit :=
   mif cumul u x y then ret tt else raise (NotCumul x y).
+
+Definition inst_cumul_or_fail {A B} (u : Unification) (x: A) (y: B) : t unit :=
+  mif inst_cumul u x y then ret tt else raise (NotCumul x y).
 
 Definition names_of_hyp : t (mlist string) :=
   env <- hyps;
@@ -946,6 +967,10 @@ Definition print_goal (g : goal gs_open) : t unit :=
   print sg;;
   ret tt.
 
+
+Definition inst_evar {A} (x y : A) : t (moption (x =m= y)) :=
+  instantiate_evar (P:=fun t => moption (t =m= y)) x y (M.ret (mSome meq_refl)) (M.ret mNone).
+
 (** [instantiate x t] tries to instantiate meta-variable [x] with [t].
     It fails with [NotAnEvar] if [x] is not a meta-variable (applied to a spine), or
     [CantInstantiate] if it fails to find a suitable instantiation. [t] is beta-reduced
@@ -955,7 +980,7 @@ Definition instantiate {A} (x y : A) : t unit :=
   dcase h as e in
     mif is_evar e then
       let t := reduce (RedWhd [rl:RedBeta]) t in
-      r <- unify x y UniEvarconv;
+      r <- inst_evar x y;
       match r with
       | mSome _ => M.ret tt
       | _ => raise (CantInstantiate x y)

--- a/theories/intf/Reduction.v
+++ b/theories/intf/Reduction.v
@@ -1,3 +1,4 @@
+From Coq Require Import String.
 From Mtac2.intf Require Import Dyn.
 
 Set Universe Polymorphism.
@@ -23,7 +24,8 @@ Monomorphic Inductive Reduction : Set :=
 | RedOneStep : redlist RedFlags -> Reduction
 | RedWhd : redlist RedFlags -> Reduction
 | RedStrong : redlist RedFlags -> Reduction
-| RedVmCompute.
+| RedVmCompute
+| RedReduction : string -> Reduction.
 
 (* Reduction primitive. It throws [NotAList] if the list of flags is not a list.  *)
 Definition reduce (r : Reduction) {A:Type} (x : A) := x.

--- a/theories/tactics/Tactics.v
+++ b/theories/tactics/Tactics.v
@@ -37,7 +37,7 @@ Import ProdNotations.
 
 Definition exact {A} (x:A) : tactic := fun g =>
   match g with
-  | Metavar _ _ g => M.cumul_or_fail UniCoq x g;; M.ret [m:]
+  | Metavar _ _ g => M.inst_cumul_or_fail UniCoq x g;; M.ret [m:]
   end.
 
 Definition eexact {A} (x:A) : tactic := fun g =>

--- a/theories/tactics/Ttactics.v
+++ b/theories/tactics/Ttactics.v
@@ -214,14 +214,14 @@ Definition with_goal_prop (F : forall (P : Prop), ttac P) : tactic := fun g =>
   match g with
   | Metavar Propₛ G g =>
     '(m: x, gs) <- F G;
-    M.cumul_or_fail UniCoq x g;;
+    M.inst_cumul_or_fail UniCoq x g;;
     M.map (fun g => M.ret (m:tt,g)) gs
   | Metavar Typeₛ G g =>
     gP <- evar Prop;
     mtry
-      cumul_or_fail UniMatch gP G;;
+      inst_cumul_or_fail UniMatch gP G;;
       '(m: x, gs) <- F gP;
-      M.cumul_or_fail UniCoq x g;;
+      M.inst_cumul_or_fail UniCoq x g;;
       M.map (fun g => M.ret (m:tt,g)) gs
     with _ => raise CantCoerce end (* its better to raise CantCoerce than NotCumul *)
   end.
@@ -233,14 +233,14 @@ Definition with_goal_type (F : forall (T : Type), ttac T) : tactic := fun g =>
   match g with
   | Metavar Propₛ G g =>
     '(m: x, gs) <- F G;
-    M.cumul_or_fail UniCoq x g;;
+    M.inst_cumul_or_fail UniCoq x g;;
     M.map (fun g => M.ret (m:tt,g)) gs
   | Metavar Typeₛ G g =>
     gP <- evar Prop;
     mtry
-      cumul_or_fail UniMatch gP G;;
+      inst_cumul_or_fail UniMatch gP G;;
       '(m: x, gs) <- F G;
-      M.cumul_or_fail UniCoq x g;;
+      M.inst_cumul_or_fail UniCoq x g;;
       M.map (fun g => M.ret (m:tt,g)) gs
     with _ => raise CantCoerce end (* its better to raise CantCoerce than NotCumul *)
   end.
@@ -251,7 +251,7 @@ Definition with_goal_sort (F : forall {s : Sort} (T : s), ttac T) (e : Exception
     match g with
     | Metavar s T g =>
       '(m: t, gs) <- F T;
-      o <- M.unify g t UniMatchNoRed;
+      o <- M.inst_evar g t;
       match o with
       | mSome _ =>
         gs <- M.map (fun x => M.ret (mpair tt x)) gs;
@@ -264,7 +264,7 @@ Definition with_goal_type' (F : forall T, ttac T) (e : Exception) : tactic :=
     match g with
     | Metavar Propₛ T g =>
       '(m: t, gs) <- F T;
-      o <- M.unify g t UniMatchNoRed;
+      o <- M.inst_evar g t;
       match o with
       | mSome _ =>
         gs <- M.map (fun x => M.ret (mpair tt x)) gs;
@@ -273,7 +273,7 @@ Definition with_goal_type' (F : forall T, ttac T) (e : Exception) : tactic :=
       end
     | Metavar Typeₛ T g =>
       '(m: t, gs) <- F T;
-      o <- M.unify g t UniMatchNoRed;
+      o <- M.inst_evar g t;
       match o with
       | mSome _ =>
         gs <- M.map (fun x => M.ret (mpair tt x)) gs;


### PR DESCRIPTION
Companion MR to https://github.com/Mtac2/Mtac2/pull/311 targetting master.

Only one commit is not included because it already exists in master:
```
commit e0663f619a61cb5942b462e9e42cb145a9edbeff
Author: Jan-Oliver Kaiser <janno@mpi-sws.org>
Date:   Fri Aug 21 15:36:51 2020 +0200

    Remove workaround for monomorphic evars in patterns.
```

@beta-ziliani I noticed while porting these commits that some bug fixes in master have not been backported to 8.12. We should probably fix that.

**TODO**:
- [x] Changelog entries (can mostly be copied from 8.12 when they are done)