### PR TITLE
Fix LHS & RHS of cumul. unif in `mrun` typecheck

### DIFF
--- a/src/metaCoqInterp.ml
+++ b/src/metaCoqInterp.ml
@@ -83,7 +83,7 @@ module MetaCoqRun = struct
     let (h, args) = Reductionops.whd_all_stack env sigma ty in
     if EConstr.eq_constr_nounivs sigma metaCoqType h && List.length args = 1 then
       try
-        let sigma = Evarconv.unify_leq_delay env sigma concl (List.hd args) in
+        let sigma = Evarconv.unify_leq_delay env sigma (List.hd args) concl in
         (true, sigma)
       with Evarconv.UnableToUnify(_,_) -> CErrors.user_err (Pp.str "Different types")
     else

--- a/tests/bug_universes.v
+++ b/tests/bug_universes.v
@@ -60,9 +60,8 @@ Definition testdef : Type -> Type := fun x=>x.
 Lemma testret : Type -> Type.
 MProof.
 M.ret (fun x=>x).
-Fail Qed. (* fails, I think it is not inferring the right universes? *)
-Abort.
-Fail Print testret.
+Qed. (* If this fails we likely swapped LHS & RHS of the cumulative unification in [ifM] *)
+Print testret.
 
 Lemma testexact : Type -> Type.
 MProof.


### PR DESCRIPTION
We need to know that the mtac code's result fits within the conclusion, not the other way around.

TODO:
- [ ] do not use `_delay`