### PR TITLE
[coq] Fix use of deprecated function

### DIFF
--- a/src/metaCoqInit.mlg
+++ b/src/metaCoqInit.mlg
@@ -68,7 +68,7 @@ let wit_mproof_instr : (MetaCoqInstr.mproof_instr, Util.Empty.t, Util.Empty.t) G
 (** We introduce a new grammar rule for MProof instructions. The type of
     the semantic values (with_mproof_instr) is specified. *)
 let mproof_instr : MetaCoqInstr.mproof_instr Pcoq.Entry.t =
-  Pcoq.create_generic_entry Pcoq.uconstr "mproof_instr" (Genarg.rawwit wit_mproof_instr)
+  Pcoq.create_generic_entry2 "mproof_instr" (Genarg.rawwit wit_mproof_instr)
 
 (** We now declare the grammar rule named [mproof_mode] as the entry point
     for proof instructions (installed by [MetaCoqMode] in [ProofGlobal]).


### PR DESCRIPTION
The `create_generic_entry` API is deprecated and scheduled for
removal, the fix is trivial as there is a replacement function.