### PR TITLE
Adapt to coq/coq#14819

### DIFF
--- a/src/metaCoqInit.mlg
+++ b/src/metaCoqInit.mlg
@@ -103,7 +103,7 @@ END
 GRAMMAR EXTEND Gram
 GLOBAL: mproof_instr;
   mproof_instr :
-    [[ c=Pcoq.Constr.operconstr ; "." -> { MetaCoqInstr.MetaCoq_constr c } ]];
+    [[ c=Pcoq.Constr.term ; "." -> { MetaCoqInstr.MetaCoq_constr c } ]];
 END
 
 {


### PR DESCRIPTION
`Pcoq.Constr.operconstr` was replaced by `Pcoq.Constr.term` in Coq 8.13 and deprecated, it could then be removed in Coq 8.15. This should then be backward compatible down to Coq 8.13.