### PR TITLE
Adapting to Coq PR #14711: Evd.univ_entry returns also the universe binders

### DIFF
--- a/src/run.ml
+++ b/src/run.ml
@@ -1246,7 +1246,7 @@ let declare_mind env sigma params sigs mut_constrs =
              mind_entry_finite=Declarations.Finite;
              mind_entry_inds;
              mind_entry_params;
-             mind_entry_universes=Evd.univ_entry ~poly:false sigma;
+             mind_entry_universes=fst(Evd.univ_entry ~poly:false sigma);
              mind_entry_template;
              mind_entry_variance=None;
              mind_entry_private=None;


### PR DESCRIPTION
The adaptation is simple. To be merged synchronously with coq/coq#14711 though. Thanks in advance.