### PR TITLE
Adapt to Coq PR #15537: schemes mrec_rect & cie have different automatically generated names

### DIFF
--- a/tests/min_bug_univpoly.v
+++ b/tests/min_bug_univpoly.v
@@ -33,7 +33,7 @@ Notation "x = y" := (x = y :>_) : type_scope.
 Notation "x <> y  :> T" := (~ x = y :>T) : type_scope.
 Notation "x <> y" := (x <> y :>_) : type_scope.
 Arguments eq_refl {A x} , [A] x.
-Arguments eq_rect [A] x P _ y _.
+Arguments eq_rect [A] x P _ y _ : rename.
 
 Section Logic_lemmas.
 

--- a/theories/lib/Logic.v
+++ b/theories/lib/Logic.v
@@ -55,9 +55,9 @@ Notation "x =m= y" := (x =m= y :>_) : type_scope.
 Arguments meq {A} x _.
 Arguments meq_refl {A x} , [A] x.
 
-Arguments meq_ind [A] x P _ y _.
-Arguments meq_rec [A] x P _ y _.
-Arguments meq_rect [A] x P _ y _.
+Arguments meq_ind [A] x P _ y _ : rename.
+Arguments meq_rec [A] x P _ y _ : rename.
+Arguments meq_rect [A] x P _ y _ : rename.
 
 
 (* Section Logic_lemmas. *)


### PR DESCRIPTION
This is a consequence of fixing a naming bug in coq/coq#15537. It now requires an explicit `rename` flag in the subsequent calls to `Arguments` for `mrec` induction schemes.

A priori, I don't see other consequences of the naming fix (except on printing, where sometimes, especially in `return` clauses, `y` will be displayed `a`).

If ok with the change, this is backward-compatible and can be merged as soon as now.
