### PR TITLE
Disable Universe Minimization ToSet in DepDestruct tests.

### DIFF
--- a/tests/DepDestruct.v
+++ b/tests/DepDestruct.v
@@ -3,6 +3,7 @@ Require Import Datatypes List Mtac2 DepDestruct Sorts.
 Import Sorts.S.
 Import T.
 Import Mtac2.lib.List.ListNotations.
+Unset Universe Minimization ToSet.
 
 Goal forall n, 0 <= n.
 MProof.


### PR DESCRIPTION
This is in preparation for https://github.com/coq/coq/pull/15847 which does something with universes.