### PR TITLE
metaCoqInit: replace Pcoq.Entry.create with Pcoq.Entry.make

### DIFF
--- a/src/metaCoqInit.mlg
+++ b/src/metaCoqInit.mlg
@@ -29,7 +29,7 @@ DECLARE PLUGIN "coq-mtac2.plugin"
 (** Introduce a new parsing rule identifier "vernac:mproof_command".
     This rule is expected to produce a vernac expression. *)
 let mproof_mode : Vernacexpr.vernac_expr Pcoq.Entry.t =
-  Pcoq.Entry.create "vernac:mproof_command"
+  Pcoq.Entry.make "vernac:mproof_command"
 
 (**
 


### PR DESCRIPTION
We are removing the deprecated Pcoq.Entry.create. See coq/coq#17065.