### PR TITLE
Fixing unsoundness in abs_prod_type

### DIFF
--- a/opam
+++ b/opam
@@ -15,5 +15,5 @@ install: [
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Mtac2"]
 depends: [
   "coq" {>= "8.16" & < "8.17~"}
-  "coq-unicoq" {>= "dev"}
+  "coq-unicoq" {>= "1.6"}
 ]

--- a/tests/bugs/abs_prod_unsoundness.v
+++ b/tests/bugs/abs_prod_unsoundness.v
@@ -1,0 +1,12 @@
+From Mtac2 Require Import Mtac2.
+
+Set Universe Polymorphism.
+
+Goal nat -> Set.
+  MProof.
+  intros n.
+  (* We cannot build something bigger than Set! This must fail. *)
+  Fail M.abs_prod_type n Set.
+  (* But building the right type works fine: *)
+  M.abs_prod_type n nat. (* nat -> nat *)
+Qed.

--- a/theories/intf/M.v
+++ b/theories/intf/M.v
@@ -98,7 +98,7 @@ Definition abs_let: forall{A: Type} {P: A->Type} (x: A) (y: A), P x -> t (let x 
 (** [abs_prod x e] returns [forall x, e]. It raises [NotAVar] if [x] is not a
     variable, or [AbsDependencyError] if [e] or its type [P] depends on a
     variable also depending on [x]. *)
-Definition abs_prod_type: forall{A: Type} (x : A), Type -> t Type.
+Definition abs_prod_type@{a y r + | a <= r, y <= r +} : forall{A: Type@{a}} (x : A), Type@{y} -> t Type@{r}.
   make. Qed.
 
 (** [abs_prod x e] returns [forall x, e]. It raises [NotAVar] if [x] is not a


### PR DESCRIPTION
Adding universe constraints to match the constructed type so no surprises arise