### PR TITLE
use new way of loading ML module, makes Unicoq module declaration superfluous

### DIFF
--- a/theories/Base.v
+++ b/theories/Base.v
@@ -1,5 +1,4 @@
-Declare ML Module "coq-unicoq.plugin".
-Declare ML Module "MetaCoqPlugin:coq-mtac2.plugin".
+Declare ML Module "coq-mtac2.plugin".
 
 (* Declare ML Module must work without the Requires to be compatible
    with async proofs. Running it before them serves as a test


### PR DESCRIPTION
See here for an example of similar change in another plugin: https://github.com/coq-community/aac-tactics/commit/04e6672d2f90c7d40d6f9fe7f8c87ab0c063cc02

The main motivation for the change is to try to work around problems with `coqdep` combined with module loading found in the Coq Platform. Here, there is only a single module loading sentence for ML that lives in the project.