### PR TITLE
Adapt w.r.t. coq/coq#20278.

### DIFF
--- a/src/run.ml
+++ b/src/run.ml
@@ -878,7 +878,7 @@ let new_env (env, sigma) hyps =
   in subs, env
 
 let make_evar sigma env ty =
-  let sigma, evar = Evarutil.new_evar env sigma ty in
+  let sigma, evar = Evarutil.new_evar ~typeclass_candidate:false env sigma ty in
   sigma, evar
 
 


### PR DESCRIPTION
The code change is backwards compatible in terms of OCaml compilation, but I did change the TC status of evars generated by Run.make_evar. The previous implicit behaviour was to mark these evars as potentially TC-resolvable, but it's not clear to me that this is a desirable default. No test is observing this subtle change of behaviour in any case.